### PR TITLE
플러스 버튼 플로팅 위치 수정

### DIFF
--- a/src/components/home/AppendButton.tsx
+++ b/src/components/home/AppendButton.tsx
@@ -43,7 +43,8 @@ export default function AppendButton() {
 const buttonCss = (theme: Theme) => css`
   position: fixed;
   right: 16px;
-  bottom: 24px;
+  bottom: calc(constant(safe-area-inset-bottom) + 24px);
+  bottom: calc(env(safe-area-inset-bottom) + 24px);
 
   display: flex;
   justify-content: center;

--- a/src/components/home/AppendTooltip.tsx
+++ b/src/components/home/AppendTooltip.tsx
@@ -31,7 +31,8 @@ export default function AppendTooltip() {
 const wrapperCss = (theme: Theme) => css`
   position: fixed;
   right: 16px;
-  bottom: 88px;
+  bottom: calc(constant(safe-area-inset-bottom) + 88px);
+  bottom: calc(env(safe-area-inset-bottom) + 88px);
 
   width: 128px;
   padding: 10px 8px;


### PR DESCRIPTION
## ⛳️작업 내용

<!-- 작업한 사항을 간략하게 적어주세요 -->

Closed #366 

홈 화면에 있는 플러스 버튼 플로팅이 safe-area가 적용되지 않으면서 생기는 이슈 같아서 수정했어요!

@positiveko 요거 확인 좀 부탁드려도 될까요!!?

## 📸스크린샷

<!-- 스크린샷으로 작업한 사항을 보여주세요 -->

![image](https://user-images.githubusercontent.com/6638675/172023234-4c83f034-570f-4021-9a43-109f37c26a09.png)


## ⚡️사용 방법

<!-- 공통 asset의 경우 사용법을 간략하게 적어봅시다 -->

## 📎레퍼런스

<!-- 참고한 레퍼런스가 있다면 기록해주세요 -->

<!--
리뷰어
혜성 : hyesungoh
도현 : ddarkr
대윤 : SenseCodeValue
은정 : positiveko
-->
