### PR TITLE
태그 추가 시 태그 리스트 반영, 영감에 태그 부착 시 영감 리스트 반영

### DIFF
--- a/src/components/common/TagForm/TagForm.tsx
+++ b/src/components/common/TagForm/TagForm.tsx
@@ -4,6 +4,7 @@ import { css } from '@emotion/react';
 import { SearchBar } from '~/components/common/TextField';
 import useGetTagListWithInfinite from '~/hooks/api/tag/useGetTagListWithInfinite';
 import useTagMutation from '~/hooks/api/tag/useTagMutation';
+import useTagRefresh from '~/hooks/api/tag/useTagRefresh';
 import useInput from '~/hooks/common/useInput';
 
 import AppliedTags from './AppliedTags';
@@ -32,16 +33,18 @@ export default function TagForm({
   const lastKeyword = useRef<string | null>(null);
   const { tags, isLoading } = useGetTagListWithInfinite({ keyword, isExactlySame: true });
   const { createTag } = useTagMutation();
+  const { refresh } = useTagRefresh();
 
   const saveCreatedTag = useCallback(
     (keyword: string) => {
       createTag(keyword, {
         onSuccess: data => {
           onSave(data);
+          refresh();
         },
       });
     },
-    [createTag, onSave]
+    [createTag, onSave, refresh]
   );
 
   useEffect(() => {

--- a/src/components/common/TagForm/TagForm.tsx
+++ b/src/components/common/TagForm/TagForm.tsx
@@ -33,18 +33,18 @@ export default function TagForm({
   const lastKeyword = useRef<string | null>(null);
   const { tags, isLoading } = useGetTagListWithInfinite({ keyword, isExactlySame: true });
   const { createTag } = useTagMutation();
-  const { refresh } = useTagRefresh();
+  const { refresh: tagListRefresh } = useTagRefresh();
 
   const saveCreatedTag = useCallback(
     (keyword: string) => {
       createTag(keyword, {
         onSuccess: data => {
           onSave(data);
-          refresh();
+          tagListRefresh();
         },
       });
     },
-    [createTag, onSave, refresh]
+    [createTag, onSave, tagListRefresh]
   );
 
   useEffect(() => {

--- a/src/hooks/api/inspiration/useInspirationMutation.ts
+++ b/src/hooks/api/inspiration/useInspirationMutation.ts
@@ -28,8 +28,8 @@ export default function useInspirationMutation() {
     queryClient.invalidateQueries([INSPIRATION_BY_ID_QUERY_KEY, `${id}`]);
   };
 
-  const resetWholeInspirationById = () => {
-    queryClient.resetQueries(INSPIRATION_BY_ID_QUERY_KEY);
+  const removeWholeInspirationById = () => {
+    queryClient.removeQueries(INSPIRATION_BY_ID_QUERY_KEY);
   };
 
   const createInspirationMutation = useMutation(
@@ -163,8 +163,8 @@ export default function useInspirationMutation() {
     resetInspirationList,
 
     /**
-     * 모든 개별 영감들을 Reset 합니다.
+     * 모든 개별 영감들을 Remove 합니다.
      */
-    resetWholeInspirationById,
+    removeWholeInspirationById,
   };
 }

--- a/src/hooks/api/inspiration/useInspirationMutation.ts
+++ b/src/hooks/api/inspiration/useInspirationMutation.ts
@@ -24,8 +24,12 @@ export default function useInspirationMutation() {
     queryClient.removeQueries(INSPIRATION_LIST_QUERY_KEY, { exact: true });
   };
 
-  const resetInspirationItem = (id: number) => {
+  const refreshInspirationById = (id: number) => {
     queryClient.invalidateQueries([INSPIRATION_BY_ID_QUERY_KEY, `${id}`]);
+  };
+
+  const resetWholeInspirationById = () => {
+    queryClient.resetQueries(INSPIRATION_BY_ID_QUERY_KEY);
   };
 
   const createInspirationMutation = useMutation(
@@ -70,7 +74,7 @@ export default function useInspirationMutation() {
     {
       onSuccess: (_res, req) => {
         fireToast({ content: '메모가 수정되었습니다!' });
-        resetInspirationItem(req.id);
+        refreshInspirationById(req.id);
       },
       onError: (error, variable, context) => {
         console.log('err', error, variable, context);
@@ -83,7 +87,7 @@ export default function useInspirationMutation() {
     {
       onSuccess: (_res, req) => {
         fireToast({ content: '태그를 추가했습니다!' });
-        resetInspirationItem(req.id);
+        refreshInspirationById(req.id);
         refreshInspirationList();
       },
       onError: (error, variable, context) => {
@@ -97,7 +101,7 @@ export default function useInspirationMutation() {
     {
       onSuccess: (_res, req) => {
         fireToast({ content: '태그를 삭제했습니다!' });
-        resetInspirationItem(req.id);
+        refreshInspirationById(req.id);
         refreshInspirationList();
       },
       onError: (error, variable, context) => {
@@ -147,5 +151,20 @@ export default function useInspirationMutation() {
      * deleteInspirationTag({id: number, tagId: number})
      */
     deleteInspirationTag: deleteInspirationTagMutation.mutate,
+
+    /**
+     * 모든 영감들을 Refresh 합니다.
+     */
+    refreshInspirationList,
+
+    /**
+     * 모든 영감들을 Reset 합니다.
+     */
+    resetInspirationList,
+
+    /**
+     * 모든 개별 영감들을 Reset 합니다.
+     */
+    resetWholeInspirationById,
   };
 }

--- a/src/hooks/api/inspiration/useInspirationMutation.ts
+++ b/src/hooks/api/inspiration/useInspirationMutation.ts
@@ -12,6 +12,10 @@ export default function useInspirationMutation() {
   const { push } = useInternalRouter();
   const { fireToast } = useToast();
 
+  const refreshInspirationList = () => {
+    queryClient.invalidateQueries(INSPIRATION_LIST_QUERY_KEY);
+  };
+
   const resetInspirationList = () => {
     queryClient.resetQueries(INSPIRATION_LIST_QUERY_KEY);
   };
@@ -80,6 +84,7 @@ export default function useInspirationMutation() {
       onSuccess: (_res, req) => {
         fireToast({ content: '태그를 추가했습니다!' });
         resetInspirationItem(req.id);
+        refreshInspirationList();
       },
       onError: (error, variable, context) => {
         console.log('err', error, variable, context);
@@ -93,6 +98,7 @@ export default function useInspirationMutation() {
       onSuccess: (_res, req) => {
         fireToast({ content: '태그를 삭제했습니다!' });
         resetInspirationItem(req.id);
+        refreshInspirationList();
       },
       onError: (error, variable, context) => {
         console.log('err', error, variable, context);

--- a/src/hooks/api/tag/useTagMutation.ts
+++ b/src/hooks/api/tag/useTagMutation.ts
@@ -12,7 +12,7 @@ interface CreateTagDataResponseInterface {
 
 export default function useTagMutation() {
   const { reset } = useTagRefresh();
-  const { resetWholeInspirationById, resetInspirationList } = useInspirationMutation();
+  const { resetInspirationList, removeWholeInspirationById } = useInspirationMutation();
 
   const createTagMutation = useMutation<
     CreateTagDataResponseInterface,
@@ -28,7 +28,7 @@ export default function useTagMutation() {
     onSuccess: () => {
       reset();
       resetInspirationList();
-      resetWholeInspirationById();
+      removeWholeInspirationById();
     },
   });
 

--- a/src/hooks/api/tag/useTagMutation.ts
+++ b/src/hooks/api/tag/useTagMutation.ts
@@ -2,6 +2,7 @@ import { useMutation } from 'react-query';
 
 import { del, post } from '~/libs/api/client';
 
+import useInspirationMutation from '../inspiration/useInspirationMutation';
 import useTagRefresh from './useTagRefresh';
 
 interface CreateTagDataResponseInterface {
@@ -10,7 +11,8 @@ interface CreateTagDataResponseInterface {
 }
 
 export default function useTagMutation() {
-  const { refresh } = useTagRefresh();
+  const { reset } = useTagRefresh();
+  const { resetWholeInspirationById, resetInspirationList } = useInspirationMutation();
 
   const createTagMutation = useMutation<
     CreateTagDataResponseInterface,
@@ -18,13 +20,15 @@ export default function useTagMutation() {
     string
   >((content: string) => post<CreateTagDataResponseInterface>('/v1/tag/add', { content }), {
     onSuccess: () => {
-      refresh();
+      reset();
     },
   });
 
   const deleteTagMutation = useMutation((id: number) => del(`/v1/tag/remove/${id}`), {
     onSuccess: () => {
-      refresh();
+      reset();
+      resetInspirationList();
+      resetWholeInspirationById();
     },
   });
 

--- a/src/hooks/api/tag/useTagRefresh.ts
+++ b/src/hooks/api/tag/useTagRefresh.ts
@@ -6,8 +6,12 @@ export default function useTagRefresh() {
   const queryClient = useQueryClient();
 
   const refresh = () => {
-    queryClient.invalidateQueries([TAG_LIST_QUERY_KEY]);
+    queryClient.invalidateQueries(TAG_LIST_QUERY_KEY);
   };
 
-  return { refresh };
+  const reset = () => {
+    queryClient.resetQueries(TAG_LIST_QUERY_KEY);
+  };
+
+  return { refresh, reset };
 }


### PR DESCRIPTION
## ⛳️작업 내용

#367 번과 #376 번을 해결했어요

- #367 번의 경우 영감을 추가할 때 영감 리스트를 invalidate하는 방식으로 해결했어요 538b3ff8e7f8a3c5fbf29e4cf8fdfb9984bd8ece

  기존에 작성돼있는 영감 추가 mutation에 refresh 로직이 부착되어 있는데, 사용하는 곳에서 `onSuccess`를 오버라이드해서 발생한 문제였어요.

- #376 번은 영감에 태그를 추가, 삭제할 때 영감 리스트를 invalidate하여 해결했어요. 636c92e252fd9fa754638dd9abedaadf74c4eb5f


- 영감 괸리 화면에서 영감을 추가, 삭제 했을 경우 홈 화면과 개별 영감 화면에서 적용되지 않는 이슈
  - 홈 화면 영감 리스트 조회를 reset 했어요
  - 영감 개별 조회 캐시를 모두 삭제해요 (어떤 영감이 해당 태그에 부착돼있는 지 모르기 때문에)

## 📸스크린샷

<!-- 스크린샷으로 작업한 사항을 보여주세요 -->

## ⚡️사용 방법

<!-- 공통 asset의 경우 사용법을 간략하게 적어봅시다 -->

## 📎레퍼런스

<!-- 참고한 레퍼런스가 있다면 기록해주세요 -->

<!--
리뷰어
혜성 : hyesungoh
도현 : ddarkr
대윤 : SenseCodeValue
은정 : positiveko
-->
