### PR TITLE
링크 섬네일에서 og 데이터가 없는 경우 멈춰버리는 현상

### DIFF
--- a/src/components/home/ThumbnailContent.tsx
+++ b/src/components/home/ThumbnailContent.tsx
@@ -1,7 +1,8 @@
-import { SyntheticEvent, useEffect, useState } from 'react';
+import { SyntheticEvent, useState } from 'react';
 import { css, Theme } from '@emotion/react';
 
 import useIgnoreOpenGraph from '~/hooks/api/inspiration/useIgnoreOpenGraph';
+import useDidUpdate from '~/hooks/common/useDidUpdate';
 import { textEllipsisCss } from '~/styles/utils';
 
 import { OpenGraph } from '../inspiration/LinkView';
@@ -72,10 +73,12 @@ function LinkContent({ openGraph, content }: Pick<ContentThumbnailProps, 'openGr
   const [src, setSrc] = useState<string>('');
   const { checkIgonreOpenGraphHost, makeURLOpenGraph } = useIgnoreOpenGraph();
 
-  useEffect(() => {
+  useDidUpdate(() => {
     setOg(checkIgonreOpenGraphHost(content) ? makeURLOpenGraph(content) : openGraph);
+  }, [content, openGraph]);
+
+  useDidUpdate(() => {
     setSrc(og && og.url && og.image ? og.url + og.image : '');
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [og]);
 
   const onImageError = (e: SyntheticEvent<HTMLImageElement>) => {


### PR DESCRIPTION
## ⛳️작업 내용

<!-- 작업한 사항을 간략하게 적어주세요 -->

- useEffect에서 동일 요소 참조가 이루어지고 있어서 문제가 생기는 것 같아서 수정했습니다! 우선 리렌더는 안일어나요

## 📸스크린샷

<!-- 스크린샷으로 작업한 사항을 보여주세요 -->

## ⚡️사용 방법

<!-- 공통 asset의 경우 사용법을 간략하게 적어봅시다 -->

## 📎레퍼런스

<!-- 참고한 레퍼런스가 있다면 기록해주세요 -->

<!--
리뷰어
혜성 : hyesungoh
도현 : ddarkr
대윤 : SenseCodeValue
은정 : positiveko
-->
