### PR TITLE
링크 영감 개별 조회에서 이미지 에러 대응

### DIFF
--- a/src/components/LinkThumbnail.tsx
+++ b/src/components/LinkThumbnail.tsx
@@ -1,5 +1,6 @@
 import { css, Theme } from '@emotion/react';
 
+import useOpenGraphImage from '~/hooks/common/useOpenGraphImage';
 import { textEllipsisCss } from '~/styles/utils';
 
 import { IconButton } from './common/Button';
@@ -22,6 +23,8 @@ export default function LinkThumbnail({
   thumbnail,
   onDelete: _onDelete,
 }: LinkThumbnailProps) {
+  const { src, onImageError } = useOpenGraphImage({ url: thumbnail.url, image: thumbnail.image });
+
   const hasImage = () => {
     return Boolean(thumbnail?.image);
   };
@@ -52,7 +55,7 @@ export default function LinkThumbnail({
           <span css={linkThumbnailUrlCss}>{thumbnail.url}</span>
         </section>
         {hasImage() && (
-          <img css={linkThumbnailImageCss} src={thumbnail.image} alt={thumbnail.alt} />
+          <img css={linkThumbnailImageCss} src={src} alt={thumbnail.alt} onError={onImageError} />
         )}
         <IconButton
           light

--- a/src/components/add/LinkInput.tsx
+++ b/src/components/add/LinkInput.tsx
@@ -1,9 +1,9 @@
 import { useCallback, useEffect, useState } from 'react';
 import { css, Theme } from '@emotion/react';
 
+import LinkThumbnail from '~/components/add/LinkThumbnail';
 import { PlusIcon } from '~/components/common/icons';
 import { Input } from '~/components/common/TextField/Input';
-import LinkThumbnail from '~/components/LinkThumbnail';
 import { useCheckLinkAvailable } from '~/hooks/api/inspiration/useCheckLinkAvailable';
 import useIgnoreOpenGraph from '~/hooks/api/inspiration/useIgnoreOpenGraph';
 import useInput from '~/hooks/common/useInput';

--- a/src/components/add/LinkThumbnail.tsx
+++ b/src/components/add/LinkThumbnail.tsx
@@ -3,16 +3,17 @@ import { css, Theme } from '@emotion/react';
 import useOpenGraphImage from '~/hooks/common/useOpenGraphImage';
 import { textEllipsisCss } from '~/styles/utils';
 
-import { IconButton } from './common/Button';
+import { IconButton } from '../common/Button';
 
-export interface LinkThumbnailMetaData {
+// TODO: /remotes/inspiration OpenGraphResponse로 대체 가능해보임
+interface LinkThumbnailMetaData {
   image?: string;
   title: string;
   url: string;
   alt?: string;
 }
 
-export interface LinkThumbnailProps {
+interface LinkThumbnailProps {
   edit?: boolean;
   thumbnail: LinkThumbnailMetaData;
   onDelete?: VoidFunction;
@@ -78,6 +79,7 @@ const linkThumbnailBoxCss = () => css`
   height: 100px;
   border-radius: 4px;
 `;
+
 const linkThumbnailContentCss = (hasImage: boolean) => (theme: Theme) =>
   css`
     padding: 16px;

--- a/src/components/home/ThumbnailContent.tsx
+++ b/src/components/home/ThumbnailContent.tsx
@@ -1,7 +1,8 @@
-import { SyntheticEvent, useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { css, Theme } from '@emotion/react';
 
 import useIgnoreOpenGraph from '~/hooks/api/inspiration/useIgnoreOpenGraph';
+import useOpenGraphImage from '~/hooks/common/useOpenGraphImage';
 import { textEllipsisCss } from '~/styles/utils';
 
 import { OpenGraph } from '../inspiration/LinkView';
@@ -65,29 +66,15 @@ const textCss = css`
 `;
 
 function LinkContent({ openGraph, content }: Pick<ContentThumbnailProps, 'openGraph' | 'content'>) {
-  // initial state를 og.url + og.image로 한 이유는
-  // og.image가 안되는 경우가 상대주소로 작성이 되어 있어 영감탱 서버에 요청하기 때문
-
   const [og, setOg] = useState<OpenGraph>();
-  const [src, setSrc] = useState<string>('');
   const { checkIgonreOpenGraphHost, makeURLOpenGraph } = useIgnoreOpenGraph();
+  const { src, onImageError } = useOpenGraphImage({ url: og?.url, image: og?.image });
 
   useEffect(() => {
     setOg(checkIgonreOpenGraphHost(content) ? makeURLOpenGraph(content) : openGraph);
-    setSrc(og && og.url && og.image ? og.url + og.image : '');
+
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [og]);
-
-  const onImageError = (e: SyntheticEvent<HTMLImageElement>) => {
-    if (!og) return;
-    if (!og.url) return;
-    if (!og.image) return;
-
-    // 두번째로 시도하는 og.image에서도 에러를 발생할 경우
-    if (e.currentTarget.src === openGraph.image) return;
-
-    setSrc(og.image);
-  };
 
   return (
     <div css={linkWrapperCss}>

--- a/src/hooks/common/useOpenGraphImage/index.test.ts
+++ b/src/hooks/common/useOpenGraphImage/index.test.ts
@@ -1,0 +1,7 @@
+import Default from './index';
+
+describe('hooks/common/useOpenGraphImage/index', () => {
+  it('default export로 정의되어 있어야함', () => {
+    expect(Default).toBeDefined();
+  });
+});

--- a/src/hooks/common/useOpenGraphImage/index.ts
+++ b/src/hooks/common/useOpenGraphImage/index.ts
@@ -1,0 +1,1 @@
+export { default } from './useOpenGraphImage';

--- a/src/hooks/common/useOpenGraphImage/useOpenGraphImage.test.ts
+++ b/src/hooks/common/useOpenGraphImage/useOpenGraphImage.test.ts
@@ -1,0 +1,36 @@
+import { SyntheticEvent } from 'react';
+import { act, renderHook } from '@testing-library/react';
+
+import useOpenGraphImage from './useOpenGraphImage';
+
+const MOCK_URL = 'https://app.ygtang.kr/';
+const MOCK_IMAGE = 'foobar.png';
+
+describe('hooks/common/useOpenGraphImage', () => {
+  it('default export로 정의되어 있어야함', () => {
+    expect(useOpenGraphImage).toBeDefined();
+  });
+
+  it('url과 image가 정의되어 있을 때 초기 src 값은 둘을 합한 값이여야함', () => {
+    const { result } = renderHook(() => useOpenGraphImage({ url: MOCK_URL, image: MOCK_IMAGE }));
+    expect(result.current.src).toBe(MOCK_URL + MOCK_IMAGE);
+  });
+
+  it('url이 정의되어있지 않을 때, 초기 src 값은 image 값이여야함', () => {
+    const { result } = renderHook(() => useOpenGraphImage({ url: undefined, image: MOCK_IMAGE }));
+    expect(result.current.src).toBe(MOCK_IMAGE);
+  });
+
+  it('url과 image가 정의되어 있을 때 이미지 에러가 발생하면 src는 image 값이여야함', () => {
+    const { result } = renderHook(() => useOpenGraphImage({ url: MOCK_URL, image: MOCK_IMAGE }));
+
+    const mockEvent = {
+      currentTarget: { src: result.current.src },
+    } as unknown as SyntheticEvent<HTMLImageElement>;
+
+    act(() => {
+      result.current.onImageError(mockEvent);
+    });
+    expect(result.current.src).toBe(MOCK_IMAGE);
+  });
+});

--- a/src/hooks/common/useOpenGraphImage/useOpenGraphImage.ts
+++ b/src/hooks/common/useOpenGraphImage/useOpenGraphImage.ts
@@ -15,13 +15,10 @@ export default function useOpenGraphImage({ url, image }: UseOpenGraphImageProps
       setSrc(url + image);
     } else if (image) {
       setSrc(image);
-    } else if (url) {
-      setSrc(url);
     }
   }, [image, url]);
 
   const onImageError = (e: SyntheticEvent<HTMLImageElement>) => {
-    if (!url) return;
     if (!image) return;
 
     // NOTE: 두번째로 시도하는 og.image에서도 에러를 발생할 경우

--- a/src/hooks/common/useOpenGraphImage/useOpenGraphImage.ts
+++ b/src/hooks/common/useOpenGraphImage/useOpenGraphImage.ts
@@ -1,0 +1,33 @@
+import { SyntheticEvent, useEffect, useState } from 'react';
+
+interface UseOpenGraphImageProps {
+  url: string | undefined;
+  image: string | undefined;
+}
+
+export default function useOpenGraphImage({ url, image }: UseOpenGraphImageProps) {
+  const [src, setSrc] = useState<string>('');
+
+  useEffect(() => {
+    // NOTE: initial state를 og.url + og.image로 한 이유는
+    // og.image가 안되는 경우가 상대주소로 작성이 되어 있어 영감탱 서버에 요청하기 때문
+    if (url && image) {
+      setSrc(url + image);
+    } else if (image) {
+      setSrc(image);
+    } else if (url) {
+      setSrc(url);
+    }
+  }, [image, url]);
+
+  const onImageError = (e: SyntheticEvent<HTMLImageElement>) => {
+    if (!url) return;
+    if (!image) return;
+
+    // NOTE: 두번째로 시도하는 og.image에서도 에러를 발생할 경우
+    if (e.currentTarget.src === image) return;
+    setSrc(image);
+  };
+
+  return { src, onImageError };
+}

--- a/src/pages/add/link.tsx
+++ b/src/pages/add/link.tsx
@@ -14,7 +14,8 @@ import { useAppliedTags } from '~/store/AppliedTags';
 import { formCss } from './image';
 
 const AddTagFormRouteAsModal = dynamic(() => import('~/components/add/AddTagFormRouteAsModal'));
-// TODO: code 200임에도 response가 null로 오는 경우가 있어서 백엔드 문의 필요
+
+// TODO: /remotes/inspiration OpenGraphResponse로 대체 가능해보임
 export interface OpenGraph {
   description: string;
   siteName: string;

--- a/src/pages/test/index.tsx
+++ b/src/pages/test/index.tsx
@@ -1,6 +1,7 @@
 import { PropsWithChildren, useEffect, useState } from 'react';
 import { css } from '@emotion/react';
 
+import LinkThumbnail from '~/components/add/LinkThumbnail';
 import Button, {
   CTAButton,
   FilledButton,
@@ -13,7 +14,6 @@ import { SearchIcon } from '~/components/common/icons';
 import NavigationBar from '~/components/common/NavigationBar';
 import TextField, { MemoText } from '~/components/common/TextField';
 import { SearchBar } from '~/components/common/TextField/SearchBar';
-import LinkThumbnail from '~/components/LinkThumbnail';
 import useInput from '~/hooks/common/useInput';
 import { useUserAgent } from '~/hooks/common/useUserAgent';
 import { useToast } from '~/store/Toast';


### PR DESCRIPTION
## ⛳️작업 내용

OpenGraph에서 image가 상대주소로 적혀있을 수도 있어, `LinkThumbnail`에서 `image`로 접근하는 것을 대체했어요.

- 기존 `ThumbnailContent` 컴포넌트에서 적용중이였던 로직을 `useOpenGraphImage`라는 hook으로 모듈화했어요
  - 해당 훅의 테스트 코드를 작성했어요
- `components/LinkThumbnail`의 디렉토리를 사용하는 곳이 `add` 한 곳이라, `components/add/LinkThumbnail`로 옮겼어요 

## 📸스크린샷

![스크린샷 2022-06-06 오전 1 11 58](https://user-images.githubusercontent.com/26461307/172059889-23b2cb4e-9723-4c53-bad0-cf8acbc2f107.png)



## ⚡️사용 방법



## 📎레퍼런스

closed #381 

<!--
리뷰어
혜성 : hyesungoh
도현 : ddarkr
대윤 : SenseCodeValue
은정 : positiveko
-->
