### PR TITLE
link http 프로토콜 부착 로직 추가

### DIFF
--- a/src/hooks/api/inspiration/useCheckLinkAvailable.ts
+++ b/src/hooks/api/inspiration/useCheckLinkAvailable.ts
@@ -10,8 +10,14 @@ interface UseCheckLinkAvailable {
 export function useCheckLinkAvailable({ link }: UseCheckLinkAvailable) {
   const INSPIRATION_LINK_OG_QUERY_KEY = 'opengraph';
 
+  const getLinkWithProtocol = (link: string) => {
+    if (link.startsWith('http')) return link;
+    return `http://${link}`;
+  };
+
   const fetchOpenGraph = (link: string): Promise<AxiosResponse<OpenGraphResponse>> => {
-    return get(`/v1/inspiration/link/availiable?link=${link}`);
+    const linkWithProtocol = getLinkWithProtocol(link);
+    return get(`/v1/inspiration/link/availiable?link=${linkWithProtocol}`);
   };
 
   const {


### PR DESCRIPTION
## ⛳️작업 내용

`http://` 혹은 `https://`로 시작하는 링크가 아닌 경우 부적합한 링크로 판단하는 것을

1. `http`로 시작하는 지 확인
2. 시작한다면 링크 그대로 사용
3. 시작하지 않는다면 `http://` 부착 하였어요

> http:// 로 요청을 하여도 대부분 https 로 리다이렉트 로직이 있기 때문에 https로 저장되어서 더 많은 범용성을 갖는 처리이지 않을까... 
생각했는데 확실하진 않아요!! 더 좋은 방법 생각해두신 게 있으면 공유부탁드려용

## 📸스크린샷

https://user-images.githubusercontent.com/26461307/172151730-55887f95-0634-4ffb-a466-c27ca7c96401.mov


<!-- 스크린샷으로 작업한 사항을 보여주세요 -->

## ⚡️사용 방법

<!-- 공통 asset의 경우 사용법을 간략하게 적어봅시다 -->

## 📎레퍼런스

<!-- 참고한 레퍼런스가 있다면 기록해주세요 -->

<!--
리뷰어
혜성 : hyesungoh
도현 : ddarkr
대윤 : SenseCodeValue
은정 : positiveko
-->
