### PR TITLE
영감 추가에서 오류 발생 시 버튼이 다시 active되지 않는 문제

### DIFF
--- a/src/hooks/api/inspiration/useInspirationMutation.ts
+++ b/src/hooks/api/inspiration/useInspirationMutation.ts
@@ -7,7 +7,18 @@ import { useToast } from '~/store/Toast';
 
 import { INSPIRATION_LIST_QUERY_KEY } from './useGetInspirationListWIthInfinite';
 
-export default function useInspirationMutation() {
+interface InspirationMutationParams {
+  /**
+   * 오류 발생 시 실행되는 공통적인 훅 함수입니다.
+   *
+   * @NOTE 현재는 `createInspirationMutation`에만 적용되어 있습니다
+   */
+  onError?: () => void;
+}
+
+export default function useInspirationMutation(param?: InspirationMutationParams) {
+  const { onError } = param ?? {};
+
   const queryClient = useQueryClient();
   const { push } = useInternalRouter();
   const { fireToast } = useToast();
@@ -41,6 +52,7 @@ export default function useInspirationMutation() {
         push('/');
       },
       onError: (error, variable, context) => {
+        onError && onError();
         console.log('err', error, variable, context);
       },
     }

--- a/src/pages/add/image.tsx
+++ b/src/pages/add/image.tsx
@@ -29,7 +29,10 @@ export default function AddImage() {
   const { imgInputUploader } = useImgUpload({});
   const { push } = useInternalRouter();
   const { uploadedImg } = useUploadedImg();
-  const { createInspiration } = useInspirationMutation();
+  const onMutationError = () => {
+    setDisabled(false);
+  };
+  const { createInspiration } = useInspirationMutation({ onError: onMutationError });
 
   useEffect(() => {
     if (!uploadedImg) push('/');

--- a/src/pages/add/link.tsx
+++ b/src/pages/add/link.tsx
@@ -23,7 +23,11 @@ export default function AddLink() {
     value: memoValue,
   } = useInput({ useDebounce: true });
   const [openGraph, setOpenGraph] = useState<OpenGraphResponse | null>(null);
-  const { createInspiration } = useInspirationMutation();
+
+  const onMutationError = () => {
+    setDisabled(false);
+  };
+  const { createInspiration } = useInspirationMutation({ onError: onMutationError });
   const { tags } = useAppliedTags(true);
 
   const saveOpenGraph = useCallback((og: OpenGraphResponse | null) => {

--- a/src/pages/add/text.tsx
+++ b/src/pages/add/text.tsx
@@ -21,7 +21,10 @@ export default function AddText() {
   const memoText = useInput({ useDebounce: true });
   const isEmptyText = !Boolean(inspiringText.debouncedValue);
   const { tags } = useAppliedTags(true);
-  const { createInspiration } = useInspirationMutation();
+  const onMutationError = () => {
+    setDisabled(false);
+  };
+  const { createInspiration } = useInspirationMutation({ onError: onMutationError });
 
   const submitText = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();


### PR DESCRIPTION
## ⛳️작업 내용

<!-- 작업한 사항을 간략하게 적어주세요 -->

Closed #391

- #391 에서 설명되어 있는 문제를 해결합니다.

mutation 상단에서 onError 함수를 받을 수 있도록 구현하였는데, 다른 의견 있으시다면 달아주셔도 좋을 것 같아요!

<img width="518" alt="image" src="https://user-images.githubusercontent.com/6638675/172297847-9644bf38-094c-481e-a5d9-30462046479a.png">

@hyesungoh 님께서 제안해주신 toast까지 추가해서 머지하겠습니다

## 📸스크린샷

<!-- 스크린샷으로 작업한 사항을 보여주세요 -->

## ⚡️사용 방법

<!-- 공통 asset의 경우 사용법을 간략하게 적어봅시다 -->

## 📎레퍼런스

<!-- 참고한 레퍼런스가 있다면 기록해주세요 -->

<!--
리뷰어
혜성 : hyesungoh
도현 : ddarkr
대윤 : SenseCodeValue
은정 : positiveko
-->
