### PR TITLE
영감 추가 오류 시 토스트 메시지 띄움

### DIFF
--- a/src/hooks/api/inspiration/useInspirationMutation.ts
+++ b/src/hooks/api/inspiration/useInspirationMutation.ts
@@ -7,7 +7,18 @@ import { useToast } from '~/store/Toast';
 
 import { INSPIRATION_LIST_QUERY_KEY } from './useGetInspirationListWIthInfinite';
 
-export default function useInspirationMutation() {
+interface InspirationMutationParams {
+  /**
+   * 오류 발생 시 실행되는 공통적인 훅 함수입니다.
+   *
+   * @NOTE 현재는 `createInspirationMutation`에만 적용되어 있습니다
+   */
+  onError?: () => void;
+}
+
+export default function useInspirationMutation(param?: InspirationMutationParams) {
+  const { onError } = param ?? {};
+
   const queryClient = useQueryClient();
   const { push } = useInternalRouter();
   const { fireToast } = useToast();
@@ -41,6 +52,7 @@ export default function useInspirationMutation() {
         push('/');
       },
       onError: (error, variable, context) => {
+        onError && onError();
         console.log('err', error, variable, context);
       },
     }

--- a/src/pages/add/image.tsx
+++ b/src/pages/add/image.tsx
@@ -29,7 +29,10 @@ export default function AddImage() {
   const { imgInputUploader } = useImgUpload({});
   const { push } = useInternalRouter();
   const { uploadedImg } = useUploadedImg();
-  const { createInspiration } = useInspirationMutation();
+  const onMutationError = () => {
+    setDisabled(false);
+  };
+  const { createInspiration } = useInspirationMutation({ onError: onMutationError });
 
   useEffect(() => {
     if (!uploadedImg) push('/');

--- a/src/pages/add/image.tsx
+++ b/src/pages/add/image.tsx
@@ -13,6 +13,7 @@ import useImgUpload from '~/hooks/common/useImgUpload';
 import useInput from '~/hooks/common/useInput';
 import useInternalRouter from '~/hooks/common/useInternalRouter';
 import { useAppliedTags } from '~/store/AppliedTags';
+import { useToast } from '~/store/Toast';
 import { useUploadedImg } from '~/store/UploadedImage';
 import { fullViewHeight } from '~/styles/utils';
 
@@ -29,7 +30,9 @@ export default function AddImage() {
   const { imgInputUploader } = useImgUpload({});
   const { push } = useInternalRouter();
   const { uploadedImg } = useUploadedImg();
+  const { fireToast } = useToast();
   const onMutationError = () => {
+    fireToast({ content: '영감 추가 도중 오류가 발생했습니다.' });
     setDisabled(false);
   };
   const { createInspiration } = useInspirationMutation({ onError: onMutationError });

--- a/src/pages/add/link.tsx
+++ b/src/pages/add/link.tsx
@@ -10,6 +10,7 @@ import { MemoText } from '~/components/common/TextField';
 import useInspirationMutation from '~/hooks/api/inspiration/useInspirationMutation';
 import useInput from '~/hooks/common/useInput';
 import { useAppliedTags } from '~/store/AppliedTags';
+import { useToast } from '~/store/Toast';
 
 import { formCss } from './image';
 
@@ -23,8 +24,10 @@ export default function AddLink() {
     value: memoValue,
   } = useInput({ useDebounce: true });
   const [openGraph, setOpenGraph] = useState<OpenGraphResponse | null>(null);
+  const { fireToast } = useToast();
 
   const onMutationError = () => {
+    fireToast({ content: '영감 추가 도중 오류가 발생했습니다.' });
     setDisabled(false);
   };
   const { createInspiration } = useInspirationMutation({ onError: onMutationError });

--- a/src/pages/add/link.tsx
+++ b/src/pages/add/link.tsx
@@ -23,7 +23,11 @@ export default function AddLink() {
     value: memoValue,
   } = useInput({ useDebounce: true });
   const [openGraph, setOpenGraph] = useState<OpenGraphResponse | null>(null);
-  const { createInspiration } = useInspirationMutation();
+
+  const onMutationError = () => {
+    setDisabled(false);
+  };
+  const { createInspiration } = useInspirationMutation({ onError: onMutationError });
   const { tags } = useAppliedTags(true);
 
   const saveOpenGraph = useCallback((og: OpenGraphResponse | null) => {

--- a/src/pages/add/text.tsx
+++ b/src/pages/add/text.tsx
@@ -10,6 +10,7 @@ import { Input } from '~/components/common/TextField/Input';
 import useInspirationMutation from '~/hooks/api/inspiration/useInspirationMutation';
 import useInput from '~/hooks/common/useInput';
 import { useAppliedTags } from '~/store/AppliedTags';
+import { useToast } from '~/store/Toast';
 
 import { formCss } from './image';
 
@@ -21,7 +22,9 @@ export default function AddText() {
   const memoText = useInput({ useDebounce: true });
   const isEmptyText = !Boolean(inspiringText.debouncedValue);
   const { tags } = useAppliedTags(true);
+  const { fireToast } = useToast();
   const onMutationError = () => {
+    fireToast({ content: '영감 추가 도중 오류가 발생했습니다.' });
     setDisabled(false);
   };
   const { createInspiration } = useInspirationMutation({ onError: onMutationError });

--- a/src/pages/add/text.tsx
+++ b/src/pages/add/text.tsx
@@ -21,7 +21,10 @@ export default function AddText() {
   const memoText = useInput({ useDebounce: true });
   const isEmptyText = !Boolean(inspiringText.debouncedValue);
   const { tags } = useAppliedTags(true);
-  const { createInspiration } = useInspirationMutation();
+  const onMutationError = () => {
+    setDisabled(false);
+  };
+  const { createInspiration } = useInspirationMutation({ onError: onMutationError });
 
   const submitText = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();


### PR DESCRIPTION
## ⛳️작업 내용

<!-- 작업한 사항을 간략하게 적어주세요 -->

함께 머지했어야되는데 실수로 머지를 먼저 해버려서... 그냥 피알 하나 더 만들었습니다.

- 영감 추가 (3개 모두)에서 오류가 발생하는 경우 toast 메세지를 띄우도록 했습니다.

## 📸스크린샷

<!-- 스크린샷으로 작업한 사항을 보여주세요 -->

## ⚡️사용 방법

<!-- 공통 asset의 경우 사용법을 간략하게 적어봅시다 -->

## 📎레퍼런스

<!-- 참고한 레퍼런스가 있다면 기록해주세요 -->

<!--
리뷰어
혜성 : hyesungoh
도현 : ddarkr
대윤 : SenseCodeValue
은정 : positiveko
-->
