### PR TITLE
회원가입 이메일 발송 로직 로딩 핸들링

### DIFF
--- a/src/components/common/Spinner/FixedSpinner.tsx
+++ b/src/components/common/Spinner/FixedSpinner.tsx
@@ -4,20 +4,25 @@ import { fullViewHeight } from '~/styles/utils';
 
 import Spinner from './Spinner';
 
-export function FixedSpinner() {
+interface FixedSpinnerProps {
+  opacity?: number;
+}
+
+export function FixedSpinner({ opacity = 1 }: FixedSpinnerProps) {
   return (
-    <div css={wrapperCss}>
+    <div css={wrapperCss(opacity)}>
       <Spinner />
     </div>
   );
 }
 
-const wrapperCss = css`
+const wrapperCss = (opacity: number) => css`
   position: fixed;
   left: 0;
   top: 0;
   width: 100vw;
   height: ${fullViewHeight()};
+  opacity: ${opacity};
 
   display: flex;
   justify-content: center;

--- a/src/pages/signup/index.tsx
+++ b/src/pages/signup/index.tsx
@@ -1,4 +1,4 @@
-import { FormEvent, useState } from 'react';
+import { FormEvent, useEffect, useState } from 'react';
 import { useRouter } from 'next/router';
 import { css, Theme } from '@emotion/react';
 
@@ -6,7 +6,6 @@ import { CTAButton } from '~/components/common/Button';
 import NavigationBar from '~/components/common/NavigationBar';
 import TextField from '~/components/common/TextField';
 import useSignupSendEmailMutation from '~/hooks/api/auth/useSignupSendEmailMutation';
-import useDidUpdate from '~/hooks/common/useDidUpdate';
 import useInput from '~/hooks/common/useInput';
 import { get } from '~/libs/api/client';
 import { useToast } from '~/store/Toast';
@@ -16,7 +15,7 @@ export default function Signup() {
   const email = useInput({ useDebounce: true });
   const [emailError, setEmailError] = useState('');
 
-  useDidUpdate(() => {
+  useEffect(() => {
     if (!validator({ type: 'email', value: email.debouncedValue })) {
       setEmailError('올바른 이메일을 입력해주세요.');
     } else {

--- a/src/pages/signup/index.tsx
+++ b/src/pages/signup/index.tsx
@@ -4,6 +4,8 @@ import { css, Theme } from '@emotion/react';
 
 import { CTAButton } from '~/components/common/Button';
 import NavigationBar from '~/components/common/NavigationBar';
+import PortalWrapper from '~/components/common/PortalWrapper';
+import { FixedSpinner } from '~/components/common/Spinner';
 import TextField from '~/components/common/TextField';
 import useSignupSendEmailMutation from '~/hooks/api/auth/useSignupSendEmailMutation';
 import useInput from '~/hooks/common/useInput';
@@ -58,6 +60,9 @@ export default function Signup() {
         <br />
         로그인과 회원가입, 비밀번호 찾기에만 사용되니 안심하세요.
       </div>
+      <PortalWrapper isShowing={isLoading}>
+        <FixedSpinner opacity={0.8} />
+      </PortalWrapper>
     </article>
   );
 }

--- a/src/pages/signup/index.tsx
+++ b/src/pages/signup/index.tsx
@@ -23,10 +23,10 @@ export default function Signup() {
     }
   }, [email.debouncedValue]);
 
-  const { onSubmit, isEmailSendingLoading } = useSignupWithCheckingEmail(email.value);
+  const { onSubmit, isLoading } = useSignupWithCheckingEmail(email.value);
 
   // NOTE: 이메일 에러 메세지가 공백이 아니면서, 비동기 로직이 로딩중일 때
-  const isCTAButtonDisabled = emailError !== '' || isEmailSendingLoading;
+  const isCTAButtonDisabled = emailError !== '' || isLoading;
 
   return (
     <article css={loginCss}>
@@ -101,8 +101,9 @@ const signUpTextWrapperCss = (theme: Theme) => css`
 function useSignupWithCheckingEmail(email: string) {
   const { fireToast } = useToast();
   const router = useRouter();
+  const [isLoading, setIsLoading] = useState<boolean>(false);
 
-  const { mutate: emailSendMutate, isLoading: isEmailSendingLoading } = useSignupSendEmailMutation({
+  const { mutate: emailSendMutate } = useSignupSendEmailMutation({
     onSuccess: () => {
       router.push({
         pathname: '/signup/sent-email',
@@ -118,6 +119,7 @@ function useSignupWithCheckingEmail(email: string) {
 
   const onSubmit = async (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault();
+    setIsLoading(true);
 
     const { data: isSignupedEmail } = await get<CheckSignupResponseInterface>(
       `/v1/signup/${email}/status`
@@ -126,6 +128,7 @@ function useSignupWithCheckingEmail(email: string) {
     // 가입되어 있을 시
     if (isSignupedEmail) {
       fireToast({ content: '이미 가입된 사용자입니다.' });
+      setIsLoading(false);
       return;
     }
 
@@ -145,5 +148,5 @@ function useSignupWithCheckingEmail(email: string) {
     }
   };
 
-  return { onSubmit, isEmailSendingLoading };
+  return { onSubmit, isLoading };
 }


### PR DESCRIPTION
## ⛳️작업 내용

- 회원가입 시 `이메일 가입 여부 확인`, `이메일 인증 여부 확인`, `이메일 발송`의 로딩을 핸들링하는 상태를 추가했어요

- 위 로딩 상태에 따라 disabled 적용 및 loading spinner를 추가헀어요

- 마운트 시에도 이메일 validate를 확인하도록 하여 초기에 disabled 상태이도록 했어요

- `FixedSpinner`에 opacity 옵션을 추가헀어요


## 📸스크린샷

<!-- 스크린샷으로 작업한 사항을 보여주세요 -->

## ⚡️사용 방법

<!-- 공통 asset의 경우 사용법을 간략하게 적어봅시다 -->

## 📎레퍼런스

<!-- 참고한 레퍼런스가 있다면 기록해주세요 -->

<!--
리뷰어
혜성 : hyesungoh
도현 : ddarkr
대윤 : SenseCodeValue
은정 : positiveko
-->
