### PR TITLE
GA, Mixpanel 이벤트 부착

### DIFF
--- a/src/components/common/TagForm/TagForm.tsx
+++ b/src/components/common/TagForm/TagForm.tsx
@@ -6,6 +6,7 @@ import useGetTagListWithInfinite from '~/hooks/api/tag/useGetTagListWithInfinite
 import useTagMutation from '~/hooks/api/tag/useTagMutation';
 import useTagRefresh from '~/hooks/api/tag/useTagRefresh';
 import useInput from '~/hooks/common/useInput';
+import { recordEvent } from '~/utils/analytics';
 
 import AppliedTags from './AppliedTags';
 import RegisteredTagList from './RegisteredTagList';
@@ -39,6 +40,7 @@ export default function TagForm({
     (keyword: string) => {
       createTag(keyword, {
         onSuccess: data => {
+          recordEvent({ action: '태그 생성', value: keyword, label: '영감 편집 화면' });
           onSave(data);
           tagListRefresh();
         },

--- a/src/components/home/Thumbnail.tsx
+++ b/src/components/home/Thumbnail.tsx
@@ -4,6 +4,7 @@ import { css, Theme } from '@emotion/react';
 import { motion, Variants } from 'framer-motion';
 
 import { defaultEasing } from '~/constants/motions';
+import { recordEvent } from '~/utils/analytics';
 import { selectRandomColor } from '~/utils/selectRandomColor';
 
 import ThumbnailContent from './ThumbnailContent';
@@ -19,6 +20,7 @@ function Thumbnail({ id, type, tags, content, openGraph }: ContentThumbnailProps
   const { push } = useRouter();
 
   const moveToInspirationView = (id: number) => {
+    recordEvent({ action: '영감 상세 조회', value: type });
     push(
       {
         query: {

--- a/src/components/inspiration/ImageView.tsx
+++ b/src/components/inspiration/ImageView.tsx
@@ -8,6 +8,7 @@ import { MemoText } from '~/components/common/TextField';
 import useInspirationMutation from '~/hooks/api/inspiration/useInspirationMutation';
 import useInput from '~/hooks/common/useInput';
 import { fullViewHeight } from '~/styles/utils';
+import { recordEvent } from '~/utils/analytics';
 
 const AddTagFormRouteAsModal = dynamic(() => import('~/components/add/AddTagFormRouteAsModal'));
 
@@ -23,6 +24,7 @@ export default function ImageView({ inspiration }: { inspiration: InspirationInt
   const saveMemo = () => {
     if (!isWriting) return setWriting(true);
     modifyInspiration({ id: inspiration.id, memo: modifiedMemo });
+    recordEvent({ action: '메모 수정' });
     setWriting(false);
   };
 

--- a/src/components/inspiration/LinkView.tsx
+++ b/src/components/inspiration/LinkView.tsx
@@ -8,6 +8,7 @@ import { MemoText } from '~/components/common/TextField';
 import useIgnoreOpenGraph from '~/hooks/api/inspiration/useIgnoreOpenGraph';
 import useInspirationMutation from '~/hooks/api/inspiration/useInspirationMutation';
 import useInput from '~/hooks/common/useInput';
+import { recordEvent } from '~/utils/analytics';
 
 import { formCss } from './ImageView';
 
@@ -27,6 +28,7 @@ export default function LinkView({ inspiration }: { inspiration: InspirationInte
   const saveMemo = () => {
     if (!isWriting) return setWriting(true);
     modifyInspiration({ id: inspiration.id, memo: memoValue });
+    recordEvent({ action: '메모 수정' });
     setWriting(false);
   };
 

--- a/src/components/inspiration/TextView.tsx
+++ b/src/components/inspiration/TextView.tsx
@@ -7,6 +7,7 @@ import { MemoText } from '~/components/common/TextField';
 import { Input } from '~/components/common/TextField/Input';
 import useInspirationMutation from '~/hooks/api/inspiration/useInspirationMutation';
 import useInput from '~/hooks/common/useInput';
+import { recordEvent } from '~/utils/analytics';
 
 import { formCss } from './ImageView';
 
@@ -21,6 +22,7 @@ export default function TextView({ inspiration }: { inspiration: InspirationInte
   const saveMemo = () => {
     if (!isWriting) return setWriting(true);
     modifyInspiration({ id: inspiration.id, memo: memoText.value });
+    recordEvent({ action: '메모 수정' });
     setWriting(false);
   };
 

--- a/src/components/my/tag/MyTagItem.tsx
+++ b/src/components/my/tag/MyTagItem.tsx
@@ -6,6 +6,7 @@ import Dialog from '~/components/common/Dialog';
 import Menu from '~/components/my/Menu';
 import useTagMutation from '~/hooks/api/tag/useTagMutation';
 import { useToast } from '~/store/Toast';
+import { recordEvent } from '~/utils/analytics';
 
 export default function MyTagItem({ tag }: { tag: TagType }) {
   const { deleteTag } = useTagMutation();
@@ -34,6 +35,7 @@ export default function MyTagItem({ tag }: { tag: TagType }) {
                 deleteTag(tag.id, {
                   onSuccess: () => {
                     fireToast({ content: '태그 삭제했습니다.' });
+                    recordEvent({ action: '태그 삭제', label: '설정 태그 편집 화면' });
                     setisTagDeleteConfirmModalOpen(false);
                   },
                 });

--- a/src/hooks/analytics/useRecordPageview.ts
+++ b/src/hooks/analytics/useRecordPageview.ts
@@ -2,6 +2,7 @@ import { useEffect } from 'react';
 import { useRouter } from 'next/router';
 import { track } from 'mixpanel-browser';
 
+import { IS_PRODUCTION } from '~/constants/common';
 import { gaPageview } from '~/libs/ga';
 
 export function useRecordPageview() {
@@ -13,9 +14,9 @@ export function useRecordPageview() {
       track('Pageview', { url });
     };
 
-    router.events.on('routeChangeComplete', recordPageview);
+    if (IS_PRODUCTION) router.events.on('routeChangeComplete', recordPageview);
     return () => {
-      router.events.off('routeChangeComplete', recordPageview);
+      if (IS_PRODUCTION) router.events.off('routeChangeComplete', recordPageview);
     };
   }, [router.events]);
 }

--- a/src/hooks/analytics/useRecordPageview.ts
+++ b/src/hooks/analytics/useRecordPageview.ts
@@ -1,14 +1,16 @@
 import { useEffect } from 'react';
 import { useRouter } from 'next/router';
+import { track } from 'mixpanel-browser';
 
 import { gaPageview } from '~/libs/ga';
 
-export function useGaPageview() {
+export function useRecordPageview() {
   const router = useRouter();
 
   useEffect(() => {
     const recordPageview = (url: string) => {
       gaPageview(url);
+      track('Pageview', { url });
     };
 
     router.events.on('routeChangeComplete', recordPageview);

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -11,8 +11,8 @@ import { RecoilRoot } from 'recoil';
 import { ErrorBoundary } from '~/components/common/ErrorBoundary';
 import ToastSection from '~/components/common/ToastSection';
 import { UserProvider } from '~/components/common/UserProvider';
+import { useRecordPageview } from '~/hooks/analytics/useRecordPageview';
 import { useWindowSize } from '~/hooks/common/useWindowSize';
-import { useGaPageview } from '~/hooks/ga/useGaPageview';
 import { queryClient } from '~/libs/api/queryClient';
 import GlobalStyle from '~/styles/GlobalStyle';
 import CustomTheme from '~/styles/Theme';
@@ -20,7 +20,7 @@ import CustomTheme from '~/styles/Theme';
 let vh = 0;
 
 export default function App({ Component, pageProps }: AppProps) {
-  useGaPageview();
+  useRecordPageview();
 
   sentryInit({ dsn: process.env.NEXT_PUBLIC_SENTRY_DSN });
   mixpanelInit(process.env.NEXT_PUBLIC_MIXPANEL_ID as string);

--- a/src/pages/add/image.tsx
+++ b/src/pages/add/image.tsx
@@ -16,6 +16,7 @@ import { useAppliedTags } from '~/store/AppliedTags';
 import { useToast } from '~/store/Toast';
 import { useUploadedImg } from '~/store/UploadedImage';
 import { fullViewHeight } from '~/styles/utils';
+import { recordEvent } from '~/utils/analytics';
 
 const AddTagFormRouteAsModal = dynamic(() => import('~/components/add/AddTagFormRouteAsModal'));
 
@@ -54,6 +55,13 @@ export default function AddImage() {
     imgData.append('type', 'IMAGE');
     imgData.append('tagIds', tagIds.toString());
 
+    recordEvent({
+      action: '영감 생성',
+      value: '이미지 영감',
+      label:
+        (memoValue.length > 0 ? '메모와 함께 영감 추가' : '메모없이 영감 추가') +
+        ` 이미지 크기: ${uploadedImg.blob.size}`,
+    });
     createInspiration(imgData);
   };
 

--- a/src/pages/add/link.tsx
+++ b/src/pages/add/link.tsx
@@ -11,6 +11,7 @@ import useInspirationMutation from '~/hooks/api/inspiration/useInspirationMutati
 import useInput from '~/hooks/common/useInput';
 import { useAppliedTags } from '~/store/AppliedTags';
 import { useToast } from '~/store/Toast';
+import { recordEvent } from '~/utils/analytics';
 
 import { formCss } from './image';
 
@@ -48,6 +49,11 @@ export default function AddLink() {
     linkData.append('type', 'LINK');
     linkData.append('tagIds', tagIds.toString());
 
+    recordEvent({
+      action: '영감 생성',
+      value: '링크 영감',
+      label: memoValue.length > 0 ? '메모와 함께 영감 추가' : '메모없이 영감 추가',
+    });
     createInspiration(linkData);
   };
 

--- a/src/pages/add/text.tsx
+++ b/src/pages/add/text.tsx
@@ -11,6 +11,7 @@ import useInspirationMutation from '~/hooks/api/inspiration/useInspirationMutati
 import useInput from '~/hooks/common/useInput';
 import { useAppliedTags } from '~/store/AppliedTags';
 import { useToast } from '~/store/Toast';
+import { recordEvent } from '~/utils/analytics';
 
 import { formCss } from './image';
 
@@ -40,6 +41,11 @@ export default function AddText() {
     textData.append('type', 'TEXT');
     textData.append('tagIds', tagIds.toString());
 
+    recordEvent({
+      action: '영감 생성',
+      value: '텍스트 영감',
+      label: memoText.value.length > 0 ? '메모와 함께 영감 추가' : '메모없이 영감 추가',
+    });
     createInspiration(textData);
   };
 

--- a/src/pages/content/index.tsx
+++ b/src/pages/content/index.tsx
@@ -15,6 +15,7 @@ import { useInspirationById } from '~/hooks/api/inspiration/useInspirationById';
 import useInspirationMutation from '~/hooks/api/inspiration/useInspirationMutation';
 import useInternalRouter from '~/hooks/common/useInternalRouter';
 import useQueryParam from '~/hooks/common/useRouterQuery';
+import { recordEvent } from '~/utils/analytics';
 
 const EditTagFormRouteAsModal = dynamic(() => import('~/components/edit/EditTagFormRouteAsModal'));
 
@@ -36,6 +37,10 @@ export default function ContentPage() {
 
   const renderInspirationViewByType = useCallback((inspiration: InspirationInterface) => {
     const type = inspiration?.type;
+
+    if (type) {
+      recordEvent({ action: '영감 상세 조회', value: type });
+    }
 
     if (type === 'IMAGE') {
       return <ImageView inspiration={inspiration} />;

--- a/src/pages/content/index.tsx
+++ b/src/pages/content/index.tsx
@@ -57,6 +57,7 @@ export default function ContentPage() {
 
   const deleteInspirationById = (id: number) => {
     deleteInspiration(id);
+    recordEvent({ action: '영감 삭제' });
     setDeleteInspirationModalOn(false);
   };
 

--- a/src/pages/content/index.tsx
+++ b/src/pages/content/index.tsx
@@ -38,10 +38,6 @@ export default function ContentPage() {
   const renderInspirationViewByType = useCallback((inspiration: InspirationInterface) => {
     const type = inspiration?.type;
 
-    if (type) {
-      recordEvent({ action: '영감 상세 조회', value: type });
-    }
-
     if (type === 'IMAGE') {
       return <ImageView inspiration={inspiration} />;
     }

--- a/src/pages/edit/tag.tsx
+++ b/src/pages/edit/tag.tsx
@@ -14,6 +14,7 @@ import useInternalRouter from '~/hooks/common/useInternalRouter';
 import useIntersectionObserver from '~/hooks/common/useIntersectionObserver';
 import useQueryParam from '~/hooks/common/useRouterQuery';
 import { useToast } from '~/store/Toast';
+import { recordEvent } from '~/utils/analytics';
 
 export default function EditTag() {
   const { fireToast } = useToast();
@@ -49,10 +50,12 @@ export default function EditTag() {
       fireToast({ content: '리스트에 태그가 이미 존재합니다.' });
       return;
     }
+    recordEvent({ action: '영감에 태그 추가', value: tag.content });
     addInspirationTag({ id: Number(inspirationId), tagId: tag.id });
   };
 
   const removeTag = (tagId: number) => {
+    recordEvent({ action: '영감에서 태그 삭제' });
     deleteInspirationTag({ id: Number(inspirationId), tagId });
   };
 

--- a/src/pages/login/index.tsx
+++ b/src/pages/login/index.tsx
@@ -9,6 +9,7 @@ import useInput from '~/hooks/common/useInput';
 import useInternalRouter from '~/hooks/common/useInternalRouter';
 import { useUser } from '~/hooks/common/useUser';
 import { useToast } from '~/store/Toast';
+import { recordEvent } from '~/utils/analytics';
 import { validator } from '~/utils/validator';
 
 export default function Login() {
@@ -62,6 +63,7 @@ export default function Login() {
         refreshToken: loginMutationData.data.refreshToken,
       });
       setIsPending(false);
+      recordEvent({ action: 'Login', value: '로그인 화면에서 로그인' });
       push('/');
     }
   }, [loginMutationData]);

--- a/src/pages/my/account/change-nickname.tsx
+++ b/src/pages/my/account/change-nickname.tsx
@@ -7,6 +7,7 @@ import useInput from '~/hooks/common/useInput';
 import useInternalRouter from '~/hooks/common/useInternalRouter';
 import { useToast } from '~/store/Toast';
 import { useUserInformation } from '~/store/UserInformation';
+import { recordEvent } from '~/utils/analytics';
 
 import { GhostButton } from '../../../components/common/Button';
 import NavigationBar from '../../../components/common/NavigationBar';
@@ -112,6 +113,7 @@ function useChangeNickname({
       { nickname: nickname.debouncedValue.trim() },
       {
         onSuccess: () => {
+          recordEvent({ action: '닉네임 변경' });
           push('/my/account');
         },
       }

--- a/src/pages/my/account/change-password.tsx
+++ b/src/pages/my/account/change-password.tsx
@@ -9,6 +9,7 @@ import useDidUpdate from '~/hooks/common/useDidUpdate';
 import useInput from '~/hooks/common/useInput';
 import useInternalRouter from '~/hooks/common/useInternalRouter';
 import { useToast } from '~/store/Toast';
+import { recordEvent } from '~/utils/analytics';
 import { validator } from '~/utils/validator';
 
 export default function MypageChangePassword() {
@@ -20,6 +21,7 @@ export default function MypageChangePassword() {
       fireToast({
         content: '비밀번호가 변경되었습니다.',
       });
+      recordEvent({ action: '비밀번호 변경' });
       push('/my/account');
     },
     onError: () => {

--- a/src/pages/my/tag/AddTagBottomSheet.tsx
+++ b/src/pages/my/tag/AddTagBottomSheet.tsx
@@ -8,6 +8,7 @@ import { SearchBar } from '~/components/common/TextField';
 import useTagMutation from '~/hooks/api/tag/useTagMutation';
 import useInput from '~/hooks/common/useInput';
 import { useToast } from '~/store/Toast';
+import { recordEvent } from '~/utils/analytics';
 
 export interface AddTagBottomSheetProps {
   isShowing: boolean;
@@ -25,6 +26,7 @@ export default function AddTagBottomSheet({ isShowing, onClose }: AddTagBottomSh
     }
     createTag(value, {
       onSuccess: () => {
+        recordEvent({ action: '태그 생성', value, label: '설정 태그 편집 화면' });
         fireToast({ content: '태그 저장 성공!' });
       },
     });

--- a/src/pages/signup/email-verified.tsx
+++ b/src/pages/signup/email-verified.tsx
@@ -12,6 +12,7 @@ import { POLICY_URL } from '~/constants/common';
 import useSignupMutation from '~/hooks/api/sign-up/useSignupMutation';
 import useDidUpdate from '~/hooks/common/useDidUpdate';
 import useInput from '~/hooks/common/useInput';
+import useToggle from '~/hooks/common/useToggle';
 import { useToast } from '~/store/Toast';
 import { recordEvent } from '~/utils/analytics';
 import { validator } from '~/utils/validator';
@@ -27,8 +28,7 @@ export default function SignUpEmailVerified() {
   const [passwordError, setPasswordError] = useState('');
   const [passwordRepeatError, setPasswordRepeatError] = useState('');
 
-  const [checkTerms, setCheckTerms] = useState(false);
-  const [checkPrivacy, setCheckPrivacy] = useState(false);
+  const { checkTerms, toggleCheckTerms, checkPrivacy, toggleCheckPrivacy } = useInternalCheckList();
 
   const {
     mutate: signupMutate,
@@ -162,14 +162,14 @@ export default function SignUpEmailVerified() {
               <CheckList
                 isChecked={checkTerms}
                 externalHref={POLICY_URL.TOS}
-                onToggle={() => setCheckTerms(!checkTerms)}
+                onToggle={() => toggleCheckTerms()}
               >
                 (필수) 서비스 이용약관에 동의
               </CheckList>
               <CheckList
                 isChecked={checkPrivacy}
                 externalHref={POLICY_URL.PRIVACY}
-                onToggle={() => setCheckPrivacy(!checkPrivacy)}
+                onToggle={() => toggleCheckPrivacy()}
               >
                 (필수) 개인정보 수집 이용에 동의
               </CheckList>
@@ -219,3 +219,10 @@ const checkListWrapperCss = css`
   display: flex;
   flex-direction: column;
 `;
+
+function useInternalCheckList() {
+  const [checkTerms, toggleCheckTerms] = useToggle(false);
+  const [checkPrivacy, toggleCheckPrivacy] = useToggle(false);
+
+  return { checkTerms, toggleCheckTerms, checkPrivacy, toggleCheckPrivacy };
+}

--- a/src/pages/signup/email-verified.tsx
+++ b/src/pages/signup/email-verified.tsx
@@ -13,6 +13,7 @@ import useSignupMutation from '~/hooks/api/sign-up/useSignupMutation';
 import useDidUpdate from '~/hooks/common/useDidUpdate';
 import useInput from '~/hooks/common/useInput';
 import { useToast } from '~/store/Toast';
+import { recordEvent } from '~/utils/analytics';
 import { validator } from '~/utils/validator';
 
 export default function SignUpEmailVerified() {
@@ -98,6 +99,11 @@ export default function SignUpEmailVerified() {
     if (signupSuccess) {
       // TODO: router.push가 안되는 문제 해결하기
       window.location.replace('/login');
+      recordEvent({
+        action: 'Signup',
+        value: '회원 가입 완료',
+        category: '이메일 인증 후 회원가입 화면',
+      });
     }
   }, [signupSuccess]);
 

--- a/src/pages/signup/index.tsx
+++ b/src/pages/signup/index.tsx
@@ -11,6 +11,7 @@ import useSignupSendEmailMutation from '~/hooks/api/auth/useSignupSendEmailMutat
 import useInput from '~/hooks/common/useInput';
 import { get } from '~/libs/api/client';
 import { useToast } from '~/store/Toast';
+import { recordEvent } from '~/utils/analytics';
 import { validator } from '~/utils/validator';
 
 export default function Signup() {
@@ -110,6 +111,7 @@ function useSignupWithCheckingEmail(email: string) {
 
   const { mutate: emailSendMutate } = useSignupSendEmailMutation({
     onSuccess: () => {
+      recordEvent({ action: 'Signup', value: '이메일 인증 요청', category: '이메일 발송 화면' });
       router.push({
         pathname: '/signup/sent-email',
         query: {
@@ -132,6 +134,11 @@ function useSignupWithCheckingEmail(email: string) {
 
     // 가입되어 있을 시
     if (isSignupedEmail) {
+      recordEvent({
+        action: 'Signup',
+        value: '가입된 이메일 가입 요청',
+        category: '이메일 발송 화면',
+      });
       fireToast({ content: '이미 가입된 사용자입니다.' });
       setIsLoading(false);
       return;
@@ -143,6 +150,11 @@ function useSignupWithCheckingEmail(email: string) {
 
     // 가입이 안되어있으며, 이메일 인증은 한 상태
     if (isCertificatedEmail) {
+      recordEvent({
+        action: 'Signup',
+        value: '인증된 이메일 가입 요청',
+        category: '이메일 발송 화면',
+      });
       fireToast({ content: '인증된 이메일입니다.' });
       router.push({
         pathname: '/signup/email-verified',

--- a/src/pages/signup/sent-email.tsx
+++ b/src/pages/signup/sent-email.tsx
@@ -10,6 +10,7 @@ import { FixedSpinner } from '~/components/common/Spinner';
 import useCheckEmailVerifiedStatusMutation from '~/hooks/api/auth/useCheckEmailVerifiedStatusMutation';
 import useSignupSendEmailMutation from '~/hooks/api/auth/useSignupSendEmailMutation';
 import { useToast } from '~/store/Toast';
+import { recordEvent } from '~/utils/analytics';
 import { validator } from '~/utils/validator';
 
 export default function SignupSentEmail() {
@@ -45,6 +46,12 @@ export default function SignupSentEmail() {
   useEffect(() => {
     if (checkEmailStatusData) {
       if (checkEmailStatusData.data) {
+        recordEvent({
+          action: 'Signup',
+          value: '이메일 인증 버튼 클릭 후 성공',
+          category: '이메일 인증 화면',
+        });
+
         push({
           pathname: '/signup/email-verified',
           query: {
@@ -59,6 +66,7 @@ export default function SignupSentEmail() {
 
   useEffect(() => {
     if (emailSendingSuccess) {
+      recordEvent({ action: 'Signup', value: '이메일 발송 재요청' });
       fireToast({ content: '인증 이메일을 재전송했어요. 메일함을 확인해주세요.' });
     }
   }, [emailSendingSuccess, fireToast]);

--- a/src/utils/analytics/event.ts
+++ b/src/utils/analytics/event.ts
@@ -1,8 +1,10 @@
 import { track } from 'mixpanel-browser';
 
+import { IS_PRODUCTION } from '~/constants/common';
 import { gaEvent } from '~/libs/ga';
 
 export function recordEvent({ action, category, label, value }: Parameters<typeof gaEvent>[0]) {
+  if (!IS_PRODUCTION) return;
   gaEvent({ action, category, label, value });
   track(action, { category, label, value });
 }

--- a/src/utils/analytics/event.ts
+++ b/src/utils/analytics/event.ts
@@ -4,5 +4,5 @@ import { gaEvent } from '~/libs/ga';
 
 export function recordEvent([{ action, category, label, value }]: Parameters<typeof gaEvent>) {
   gaEvent({ action, category, label, value });
-  track(action);
+  track(action, { category, label, value });
 }

--- a/src/utils/analytics/event.ts
+++ b/src/utils/analytics/event.ts
@@ -2,7 +2,7 @@ import { track } from 'mixpanel-browser';
 
 import { gaEvent } from '~/libs/ga';
 
-export function recordEvent([{ action, category, label, value }]: Parameters<typeof gaEvent>) {
+export function recordEvent({ action, category, label, value }: Parameters<typeof gaEvent>[0]) {
   gaEvent({ action, category, label, value });
   track(action, { category, label, value });
 }


### PR DESCRIPTION
## ⛳️작업 내용

- 페이지뷰, 이벤트 부착 로직을 프로덕션 환경에서만 동작하도록 했어요
  - 믹스패널의 경우 init이 되어있지 않으면 오류가 발생하더라구요 (개발 환경)

- 다음 동작에 이벤트를 부착했어요
  - 회원가입 - 이메일 인증 요청
  - 회원가입 - 가입된 이메일이 가입 요청
  - 회원가입 - 인증된 이메일이 가입 요청
  - 회원가입 - 이메일 인증 버튼 클릭
  - 회원가입 - 이메일 재발송 요청
  - 회원가입 - 회원 가입 완료
  
  - 로그인 시
  - 영감 생성 시 (각 타입별)
  - 영감 조회 시 (각 타입별)
  - 닉네임 변경
  - 비밀번호 변경
  - 설정 - 태그 추가
  - 설정 - 태그 삭제
  - 영감 태그 편집 - 태그 생성
  - 영감 태그 편집 - 태그 부착
  - 영감 태그 편집 - 태그 탈착
  - 메모 수정
  - 영감 삭제


- 회원가입 시에 체크박스 로직을 분리 및 `useToggle`을 사용하도록 리팩토링했어요

## 📸스크린샷

<!-- 스크린샷으로 작업한 사항을 보여주세요 -->

## ⚡️사용 방법

<!-- 공통 asset의 경우 사용법을 간략하게 적어봅시다 -->

## 📎레퍼런스

<!-- 참고한 레퍼런스가 있다면 기록해주세요 -->

<!--
리뷰어
혜성 : hyesungoh
도현 : ddarkr
대윤 : SenseCodeValue
은정 : positiveko
-->

closed #400 
