### PR TITLE
링크 확인 로직 변경 + 로딩 핸들링

### DIFF
--- a/src/components/add/LinkInput.tsx
+++ b/src/components/add/LinkInput.tsx
@@ -18,7 +18,12 @@ interface LinkInputProps {
 export default function LinkInput({ openGraph, saveOpenGraph }: LinkInputProps) {
   const { asPath } = useInternalRouter();
   const url = useInput({ useDebounce: true });
-  const { openGraph: og, refetch, isFetching } = useCheckLinkAvailable({ link: url.value });
+  const {
+    openGraph: og,
+    refetch,
+    isFetching,
+    isCheckingLinkWithAllProtocol,
+  } = useCheckLinkAvailable({ link: url.debouncedValue });
 
   const { fireToast } = useToast();
 
@@ -41,10 +46,10 @@ export default function LinkInput({ openGraph, saveOpenGraph }: LinkInputProps) 
 
   useEffect(() => {
     if (isFetching || !og) return;
-    if (og.url === null) return showErrorMessage();
+    if (isCheckingLinkWithAllProtocol && og.url === null) return showErrorMessage();
 
     if (saveOpenGraph) saveOpenGraph(og);
-  }, [isFetching, og, saveOpenGraph, showErrorMessage]);
+  }, [isCheckingLinkWithAllProtocol, isFetching, og, saveOpenGraph, showErrorMessage]);
 
   return (
     <div css={LinkInputCss}>

--- a/src/components/add/LinkInput.tsx
+++ b/src/components/add/LinkInput.tsx
@@ -10,6 +10,9 @@ import useInternalRouter from '~/hooks/common/useInternalRouter';
 import { useToast } from '~/store/Toast';
 import { validator } from '~/utils/validator';
 
+import PortalWrapper from '../common/PortalWrapper';
+import { FixedSpinner } from '../common/Spinner';
+
 interface LinkInputProps {
   openGraph: OpenGraphResponse | null;
   saveOpenGraph?: (og: OpenGraphResponse | null) => void;
@@ -45,8 +48,10 @@ export default function LinkInput({ openGraph, saveOpenGraph }: LinkInputProps) 
   };
 
   useEffect(() => {
-    if (isFetching || !og) return;
-    if (isCheckingLinkWithAllProtocol && og.url === null) return showErrorMessage();
+    if (!og) return;
+    if (isFetching) return;
+    if (!isCheckingLinkWithAllProtocol) return;
+    if (og.url === null) return showErrorMessage();
 
     if (saveOpenGraph) saveOpenGraph(og);
   }, [isCheckingLinkWithAllProtocol, isFetching, og, saveOpenGraph, showErrorMessage]);
@@ -70,6 +75,10 @@ export default function LinkInput({ openGraph, saveOpenGraph }: LinkInputProps) 
           <PlusBtn onClick={getOpenGraph} />
         </section>
       )}
+
+      <PortalWrapper isShowing={isFetching}>
+        <FixedSpinner opacity={0.8} />
+      </PortalWrapper>
     </div>
   );
 }

--- a/src/hooks/api/inspiration/useCheckLinkAvailable.ts
+++ b/src/hooks/api/inspiration/useCheckLinkAvailable.ts
@@ -3,23 +3,16 @@ import { useQuery } from 'react-query';
 
 import { get } from '~/libs/api/client';
 
-interface UseCheckLinkAvailable {
+const INSPIRATION_LINK_OG_QUERY_KEY = 'opengraph';
+
+interface UseCheckLinkAvailableProps {
   link: string;
 }
 
-export function useCheckLinkAvailable({ link }: UseCheckLinkAvailable) {
-  const INSPIRATION_LINK_OG_QUERY_KEY = 'opengraph';
+// TODO: 1. 기본 요청 > 실패 시 https 요청 > 실패 시 http 요청
+// TODO: 2. 바로 https 요청
 
-  const getLinkWithProtocol = (link: string) => {
-    if (link.startsWith('http')) return link;
-    return `http://${link}`;
-  };
-
-  const fetchOpenGraph = (link: string): Promise<AxiosResponse<OpenGraphResponse>> => {
-    const linkWithProtocol = getLinkWithProtocol(link);
-    return get(`/v1/inspiration/link/availiable?link=${linkWithProtocol}`);
-  };
-
+export function useCheckLinkAvailable({ link }: UseCheckLinkAvailableProps) {
   const {
     data: openGraph,
     refetch,
@@ -32,6 +25,17 @@ export function useCheckLinkAvailable({ link }: UseCheckLinkAvailable) {
       keepPreviousData: true,
     }
   );
+
+  const getLinkWithProtocol = (link: string) => {
+    if (link.startsWith('http')) return link;
+    return `https://${link}`;
+  };
+
+  const fetchOpenGraph = (link: string): Promise<AxiosResponse<OpenGraphResponse>> => {
+    const linkWithProtocol = getLinkWithProtocol(link);
+    console.log('fetch');
+    return get(`/v1/inspiration/link/availiable?link=${linkWithProtocol}`);
+  };
 
   return { openGraph, refetch, isFetching };
 }

--- a/src/hooks/api/inspiration/useCheckLinkAvailable.ts
+++ b/src/hooks/api/inspiration/useCheckLinkAvailable.ts
@@ -15,6 +15,7 @@ export function useCheckLinkAvailable({ link }: UseCheckLinkAvailableProps) {
   const {
     data: openGraph,
     refetch,
+    remove,
     isFetching,
   } = useQuery<OpenGraphResponse>(
     [INSPIRATION_LINK_OG_QUERY_KEY, link],
@@ -40,6 +41,7 @@ export function useCheckLinkAvailable({ link }: UseCheckLinkAvailableProps) {
     isFetchedWith.current.pure = false;
     isFetchedWith.current.https = false;
     isFetchedWith.current.http = false;
+    isCheckingLinkWithAllProtocol.current = false;
   }, [link]);
 
   const getLinkWithProtocol = (link: string) => {
@@ -80,6 +82,7 @@ export function useCheckLinkAvailable({ link }: UseCheckLinkAvailableProps) {
       isFetchedWith.current.https === false ||
       isFetchedWith.current.http === false
     ) {
+      remove();
       refetch();
       return;
     }

--- a/src/hooks/api/inspiration/useCheckLinkAvailable.ts
+++ b/src/hooks/api/inspiration/useCheckLinkAvailable.ts
@@ -1,6 +1,8 @@
+import { useRef } from 'react';
 import { AxiosResponse } from 'axios';
 import { useQuery } from 'react-query';
 
+import useDidUpdate from '~/hooks/common/useDidUpdate';
 import { get } from '~/libs/api/client';
 
 const INSPIRATION_LINK_OG_QUERY_KEY = 'opengraph';
@@ -8,9 +10,6 @@ const INSPIRATION_LINK_OG_QUERY_KEY = 'opengraph';
 interface UseCheckLinkAvailableProps {
   link: string;
 }
-
-// TODO: 1. 기본 요청 > 실패 시 https 요청 > 실패 시 http 요청
-// TODO: 2. 바로 https 요청
 
 export function useCheckLinkAvailable({ link }: UseCheckLinkAvailableProps) {
   const {
@@ -26,16 +25,73 @@ export function useCheckLinkAvailable({ link }: UseCheckLinkAvailableProps) {
     }
   );
 
+  // NOTE: 모든 프로토콜로 확인이 끝났을 때
+  const isCheckingLinkWithAllProtocol = useRef(false);
+
+  // NOTE: 각 프로토콜별 실행 유무
+  const isFetchedWith = useRef({
+    pure: false,
+    https: false,
+    http: false,
+  });
+
+  // NOTE: 링크가 변경될 시 실행 유무 초기화
+  useDidUpdate(() => {
+    isFetchedWith.current.pure = false;
+    isFetchedWith.current.https = false;
+    isFetchedWith.current.http = false;
+  }, [link]);
+
   const getLinkWithProtocol = (link: string) => {
-    if (link.startsWith('http')) return link;
-    return `https://${link}`;
+    // NOTE: 1순위 사용자가 입력한 형태로 요청
+    if (isFetchedWith.current.pure === false) {
+      isFetchedWith.current.pure = true;
+      return link;
+    }
+    // NOTE: 2순위 https로 시작하지 않는다면 https://와 함께 요청
+    if (isFetchedWith.current.https === false && link.startsWith('https') === false) {
+      isFetchedWith.current.https = true;
+      return `https://${link}`;
+    }
+    // NOTE: 3순위 http로 시작하지 않는다면 http://와 함께 요청
+    if (isFetchedWith.current.http === false && link.startsWith('http') === false) {
+      isFetchedWith.current.http = true;
+      return `http://${link}`;
+    }
   };
 
   const fetchOpenGraph = (link: string): Promise<AxiosResponse<OpenGraphResponse>> => {
     const linkWithProtocol = getLinkWithProtocol(link);
-    console.log('fetch');
+    console.log('fetched with' + linkWithProtocol);
     return get(`/v1/inspiration/link/availiable?link=${linkWithProtocol}`);
   };
 
-  return { openGraph, refetch, isFetching };
+  useDidUpdate(() => {
+    if (!openGraph) return;
+    // NOTE: openGraph가 재시도되면서 url 값이 있을 시 종료
+    if (openGraph.url) {
+      isCheckingLinkWithAllProtocol.current = true;
+      return;
+    }
+
+    // NOTE: 세 방법 중 하나라도 시도해보지 않았다면 재시도
+    if (
+      isFetchedWith.current.pure === false ||
+      isFetchedWith.current.https === false ||
+      isFetchedWith.current.http === false
+    ) {
+      refetch();
+      return;
+    }
+
+    // NOTE: 모두 재시도하였을 때
+    isCheckingLinkWithAllProtocol.current = true;
+  }, [openGraph]);
+
+  return {
+    openGraph,
+    refetch,
+    isFetching,
+    isCheckingLinkWithAllProtocol: isCheckingLinkWithAllProtocol.current,
+  };
 }

--- a/src/hooks/api/inspiration/useCheckLinkAvailable.ts
+++ b/src/hooks/api/inspiration/useCheckLinkAvailable.ts
@@ -1,4 +1,4 @@
-import { useRef } from 'react';
+import { useRef, useState } from 'react';
 import { AxiosResponse } from 'axios';
 import { useQuery } from 'react-query';
 
@@ -27,7 +27,8 @@ export function useCheckLinkAvailable({ link }: UseCheckLinkAvailableProps) {
   );
 
   // NOTE: 모든 프로토콜로 확인이 끝났을 때
-  const isCheckingLinkWithAllProtocol = useRef(false);
+  const [isCheckingLinkWithAllProtocol, setIsCheckingLinkWithAllProtocol] =
+    useState<boolean>(false);
 
   // NOTE: 각 프로토콜별 실행 유무
   const isFetchedWith = useRef({
@@ -41,7 +42,7 @@ export function useCheckLinkAvailable({ link }: UseCheckLinkAvailableProps) {
     isFetchedWith.current.pure = false;
     isFetchedWith.current.https = false;
     isFetchedWith.current.http = false;
-    isCheckingLinkWithAllProtocol.current = false;
+    setIsCheckingLinkWithAllProtocol(false);
   }, [link]);
 
   const getLinkWithProtocol = (link: string) => {
@@ -64,15 +65,15 @@ export function useCheckLinkAvailable({ link }: UseCheckLinkAvailableProps) {
 
   const fetchOpenGraph = (link: string): Promise<AxiosResponse<OpenGraphResponse>> => {
     const linkWithProtocol = getLinkWithProtocol(link);
-    console.log('fetched with' + linkWithProtocol);
     return get(`/v1/inspiration/link/availiable?link=${linkWithProtocol}`);
   };
 
   useDidUpdate(() => {
     if (!openGraph) return;
+
     // NOTE: openGraph가 재시도되면서 url 값이 있을 시 종료
     if (openGraph.url) {
-      isCheckingLinkWithAllProtocol.current = true;
+      setIsCheckingLinkWithAllProtocol(true);
       return;
     }
 
@@ -88,13 +89,13 @@ export function useCheckLinkAvailable({ link }: UseCheckLinkAvailableProps) {
     }
 
     // NOTE: 모두 재시도하였을 때
-    isCheckingLinkWithAllProtocol.current = true;
+    setIsCheckingLinkWithAllProtocol(true);
   }, [openGraph]);
 
   return {
     openGraph,
     refetch,
     isFetching,
-    isCheckingLinkWithAllProtocol: isCheckingLinkWithAllProtocol.current,
+    isCheckingLinkWithAllProtocol,
   };
 }


### PR DESCRIPTION
## ⛳️작업 내용

- 링크 확인 시 다음과 같은 순서로 바꾸었어요

1. 사용자가 입력한 값 조회
2. 실패할 시 (url값이 없을 시) + https로 시작하지 않을 시, https 부착하여 조회
3. 실패할 시 + http로 시작하지 않을 시, http 부착하여 조회

- 기존 유효하지 않은 주소 토스트 메세지 로직을, 모든 방법으로 조회하였으나 실패한 경우에 발생하도록 했어요

- 링크를 확인하는 도중 로딩 스피너를 보여주었어요


## 📸스크린샷

<!-- 스크린샷으로 작업한 사항을 보여주세요 -->

## ⚡️사용 방법

<!-- 공통 asset의 경우 사용법을 간략하게 적어봅시다 -->

## 📎레퍼런스

<!-- 참고한 레퍼런스가 있다면 기록해주세요 -->

<!--
리뷰어
혜성 : hyesungoh
도현 : ddarkr
대윤 : SenseCodeValue
은정 : positiveko
-->

closed #402 
