### PR TITLE
fix: image content min-height 100px로 수정

### DIFF
--- a/src/components/common/ImageContent.tsx
+++ b/src/components/common/ImageContent.tsx
@@ -44,8 +44,8 @@ const imgBoxCss = ({
 }) => css`
   position: relative;
   width: ${width};
-  min-height: ${height ?? '343px'};
-  height: 100%;
+  height: ${height};
+  min-height: '100px';
   overflow: hidden;
   border-radius: 4px;
   object-fit: cover;


### PR DESCRIPTION
## ⛳️작업 내용
### image content min-height 100px로 수정
<!-- 작업한 사항을 간략하게 적어주세요 -->

## 📸스크린샷

<!-- 스크린샷으로 작업한 사항을 보여주세요 -->
![IMG_75D2FDE5BE35-1](https://user-images.githubusercontent.com/69200669/173268757-7d53ce24-d10e-4db3-84a7-41d884663ad0.jpeg)
<img width="494" alt="image" src="https://user-images.githubusercontent.com/69200669/173268823-f2fcaea9-e86b-469f-bfb7-6fe31b1af392.png">

## ⚡️사용 방법

<!-- 공통 asset의 경우 사용법을 간략하게 적어봅시다 -->

## 📎레퍼런스

<!-- 참고한 레퍼런스가 있다면 기록해주세요 -->

<!--
리뷰어
혜성 : hyesungoh
도현 : ddarkr
대윤 : SenseCodeValue
은정 : positiveko
-->
