### PR TITLE
영감 조회시 로딩 핸들링 수정

### DIFF
--- a/src/components/common/Spinner/FixedSpinner.tsx
+++ b/src/components/common/Spinner/FixedSpinner.tsx
@@ -18,8 +18,10 @@ export function FixedSpinner({ opacity = 1 }: FixedSpinnerProps) {
 
 const wrapperCss = (opacity: number) => css`
   position: fixed;
-  left: 0;
   top: 0;
+  /* 가로 가운데 정렬 */
+  left: 50%;
+  transform: translateX(-50%);
   width: 100vw;
   height: ${fullViewHeight()};
   opacity: ${opacity};

--- a/src/pages/content/index.tsx
+++ b/src/pages/content/index.tsx
@@ -47,10 +47,6 @@ export default function ContentPage() {
     return <TextView inspiration={inspiration} />;
   }, []);
 
-  if (!inspiration) return <></>;
-
-  const { id } = inspiration;
-
   const deleteInspirationById = (id: number) => {
     deleteInspiration(id);
     recordEvent({ action: '영감 삭제' });
@@ -81,7 +77,7 @@ export default function ContentPage() {
             animate="animate"
             exit="exit"
           >
-            {renderInspirationViewByType(inspiration)}
+            {inspiration && renderInspirationViewByType(inspiration)}
           </motion.section>
         </LoadingHandler>
 
@@ -90,7 +86,10 @@ export default function ContentPage() {
           isShowing={isDeleteInspirationModalOn}
           actionButtons={
             <>
-              <FilledButton colorType="light" onClick={() => deleteInspirationById(id)}>
+              <FilledButton
+                colorType="light"
+                onClick={() => inspiration && deleteInspirationById(inspiration.id)}
+              >
                 네
               </FilledButton>
               <FilledButton colorType="dark" onClick={() => setDeleteInspirationModalOn(false)}>


### PR DESCRIPTION
## ⛳️작업 내용

- `FixedSpinner` 컴포넌트가 간혈적으로 가로 가운데 정렬이 되지 않는 것을 해결했어요

- 영감 조회 시 로딩 처리가 되지 않는 것을 해결했어요
  - 영감이 없을 시 early return하는 것이 문제였어요
 

## 📸스크린샷

<!-- 스크린샷으로 작업한 사항을 보여주세요 -->

## ⚡️사용 방법

<!-- 공통 asset의 경우 사용법을 간략하게 적어봅시다 -->

## 📎레퍼런스

<!-- 참고한 레퍼런스가 있다면 기록해주세요 -->

<!--
리뷰어
혜성 : hyesungoh
도현 : ddarkr
대윤 : SenseCodeValue
은정 : positiveko
-->

closed #403 
closed #415 
