### PR TITLE
영감 생성시 로딩 처리

### DIFF
--- a/src/hooks/api/inspiration/useInspirationMutation.ts
+++ b/src/hooks/api/inspiration/useInspirationMutation.ts
@@ -130,6 +130,11 @@ export default function useInspirationMutation(param?: InspirationMutationParams
     createInspiration: createInspirationMutation.mutate,
 
     /**
+     * 영감 추가의 로딩 상태입니다.
+     */
+    isCreateInspirationLoading: createInspirationMutation.isLoading,
+
+    /**
      * 영감을 삭제합니다.
      * deleteInspiration(id: number);
      */

--- a/src/pages/add/image.tsx
+++ b/src/pages/add/image.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect } from 'react';
 import dynamic from 'next/dynamic';
 import { css } from '@emotion/react';
 
@@ -7,6 +7,8 @@ import { CTABottomButton } from '~/components/common/Button';
 import TagContent from '~/components/common/Content/TagContent';
 import ImageContent from '~/components/common/ImageContent';
 import NavigationBar from '~/components/common/NavigationBar';
+import PortalWrapper from '~/components/common/PortalWrapper';
+import { FixedSpinner } from '~/components/common/Spinner';
 import { MemoText } from '~/components/common/TextField';
 import useInspirationMutation from '~/hooks/api/inspiration/useInspirationMutation';
 import useImgUpload from '~/hooks/common/useImgUpload';
@@ -21,7 +23,6 @@ import { recordEvent } from '~/utils/analytics';
 const AddTagFormRouteAsModal = dynamic(() => import('~/components/add/AddTagFormRouteAsModal'));
 
 export default function AddImage() {
-  const [disabled, setDisabled] = useState(false);
   const {
     onChange: onMemoChange,
     debouncedValue: memoDebouncedValue,
@@ -32,11 +33,14 @@ export default function AddImage() {
   const { push } = useInternalRouter();
   const { uploadedImg } = useUploadedImg();
   const { fireToast } = useToast();
+
   const onMutationError = () => {
     fireToast({ content: '영감 추가 도중 오류가 발생했습니다.' });
-    setDisabled(false);
   };
-  const { createInspiration } = useInspirationMutation({ onError: onMutationError });
+
+  const { createInspiration, isCreateInspirationLoading } = useInspirationMutation({
+    onError: onMutationError,
+  });
 
   useEffect(() => {
     if (!uploadedImg) push('/');
@@ -47,7 +51,7 @@ export default function AddImage() {
   const submitImg = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
     if (!uploadedImg) return;
-    setDisabled(true);
+
     const tagIds = tags.map(tag => tag.id);
     const imgData = new FormData();
     imgData.append('file', uploadedImg.blob);
@@ -94,13 +98,16 @@ export default function AddImage() {
           </section>
 
           <section css={addImageBottomCss}>
-            <CTABottomButton disabled={disabled} type="submit">
+            <CTABottomButton disabled={isCreateInspirationLoading} type="submit">
               Tang!
             </CTABottomButton>
           </section>
         </form>
       </article>
       <AddTagFormRouteAsModal />
+      <PortalWrapper isShowing={isCreateInspirationLoading}>
+        <FixedSpinner opacity={0.8} />
+      </PortalWrapper>
     </>
   );
 }

--- a/src/pages/add/link.tsx
+++ b/src/pages/add/link.tsx
@@ -97,7 +97,7 @@ export default function AddLink() {
       <AddTagFormRouteAsModal />
 
       <PortalWrapper isShowing={isCreateInspirationLoading}>
-        <FixedSpinner />
+        <FixedSpinner opacity={0.8} />
       </PortalWrapper>
     </>
   );

--- a/src/pages/add/link.tsx
+++ b/src/pages/add/link.tsx
@@ -6,6 +6,8 @@ import LinkInput from '~/components/add/LinkInput';
 import { CTABottomButton } from '~/components/common/Button';
 import TagContent from '~/components/common/Content/TagContent';
 import NavigationBar from '~/components/common/NavigationBar';
+import PortalWrapper from '~/components/common/PortalWrapper';
+import { FixedSpinner } from '~/components/common/Spinner';
 import { MemoText } from '~/components/common/TextField';
 import useInspirationMutation from '~/hooks/api/inspiration/useInspirationMutation';
 import useInput from '~/hooks/common/useInput';
@@ -18,20 +20,23 @@ import { formCss } from './image';
 const AddTagFormRouteAsModal = dynamic(() => import('~/components/add/AddTagFormRouteAsModal'));
 
 export default function AddLink() {
-  const [disabled, setDisabled] = useState(false);
   const {
     onChange: onMemoChange,
     debouncedValue: memoDebouncedValue,
     value: memoValue,
   } = useInput({ useDebounce: true });
+
   const [openGraph, setOpenGraph] = useState<OpenGraphResponse | null>(null);
   const { fireToast } = useToast();
 
   const onMutationError = () => {
     fireToast({ content: '영감 추가 도중 오류가 발생했습니다.' });
-    setDisabled(false);
   };
-  const { createInspiration } = useInspirationMutation({ onError: onMutationError });
+
+  const { createInspiration, isCreateInspirationLoading } = useInspirationMutation({
+    onError: onMutationError,
+  });
+
   const { tags } = useAppliedTags(true);
 
   const saveOpenGraph = useCallback((og: OpenGraphResponse | null) => {
@@ -41,7 +46,6 @@ export default function AddLink() {
   const submitLink = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
     if (!openGraph || !openGraph.url) return;
-    setDisabled(true);
     const tagIds = tags.map(tag => tag.id);
     const linkData = new FormData();
     linkData.append('content', openGraph.url);
@@ -81,13 +85,20 @@ export default function AddLink() {
           </section>
 
           <section css={addLinkBottomCss}>
-            <CTABottomButton disabled={!Boolean(openGraph) || disabled} type="submit">
+            <CTABottomButton
+              disabled={!Boolean(openGraph) || isCreateInspirationLoading}
+              type="submit"
+            >
               Tang!
             </CTABottomButton>
           </section>
         </form>
       </article>
       <AddTagFormRouteAsModal />
+
+      <PortalWrapper isShowing={isCreateInspirationLoading}>
+        <FixedSpinner />
+      </PortalWrapper>
     </>
   );
 }

--- a/src/pages/add/text.tsx
+++ b/src/pages/add/text.tsx
@@ -1,10 +1,11 @@
-import { useState } from 'react';
 import dynamic from 'next/dynamic';
 import { css } from '@emotion/react';
 
 import { CTABottomButton } from '~/components/common/Button';
 import TagContent from '~/components/common/Content/TagContent';
 import NavigationBar from '~/components/common/NavigationBar';
+import PortalWrapper from '~/components/common/PortalWrapper';
+import { FixedSpinner } from '~/components/common/Spinner';
 import { MemoText } from '~/components/common/TextField';
 import { Input } from '~/components/common/TextField/Input';
 import useInspirationMutation from '~/hooks/api/inspiration/useInspirationMutation';
@@ -18,22 +19,24 @@ import { formCss } from './image';
 const AddTagFormRouteAsModal = dynamic(() => import('~/components/add/AddTagFormRouteAsModal'));
 
 export default function AddText() {
-  const [disabled, setDisabled] = useState(false);
   const inspiringText = useInput({ useDebounce: true });
   const memoText = useInput({ useDebounce: true });
   const isEmptyText = !Boolean(inspiringText.debouncedValue);
   const { tags } = useAppliedTags(true);
   const { fireToast } = useToast();
+
   const onMutationError = () => {
     fireToast({ content: '영감 추가 도중 오류가 발생했습니다.' });
-    setDisabled(false);
   };
-  const { createInspiration } = useInspirationMutation({ onError: onMutationError });
+
+  const { createInspiration, isCreateInspirationLoading } = useInspirationMutation({
+    onError: onMutationError,
+  });
 
   const submitText = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
     if (!inspiringText.value) return;
-    setDisabled(true);
+
     const textData = new FormData();
     const tagIds = tags.map(tag => tag.id);
     textData.append('content', inspiringText.value);
@@ -78,13 +81,17 @@ export default function AddText() {
           </section>
 
           <section css={addTextBottomCss}>
-            <CTABottomButton type="submit" disabled={isEmptyText || disabled}>
+            <CTABottomButton type="submit" disabled={isEmptyText || isCreateInspirationLoading}>
               Tang!
             </CTABottomButton>
           </section>
         </form>
       </article>
       <AddTagFormRouteAsModal />
+
+      <PortalWrapper isShowing={isCreateInspirationLoading}>
+        <FixedSpinner opacity={0.8} />
+      </PortalWrapper>
     </>
   );
 }


### PR DESCRIPTION
## ⛳️작업 내용

- 영감 생성 (로딩) 시를 기존 `disabled` state로 관리하던 것을 `useQuery`의 `isLoading`으로 위임했어요

- 로딩 중 FixedSpinner를 렌더링했어요
  - 느린 인터넷 상황에서 중복 업로드 방지되는 것 확인했슴다 

## 📸스크린샷

<!-- 스크린샷으로 작업한 사항을 보여주세요 -->

## ⚡️사용 방법

<!-- 공통 asset의 경우 사용법을 간략하게 적어봅시다 -->

## 📎레퍼런스

<!-- 참고한 레퍼런스가 있다면 기록해주세요 -->

<!--
리뷰어
혜성 : hyesungoh
도현 : ddarkr
대윤 : SenseCodeValue
은정 : positiveko
-->
