### PR TITLE
영감 공유하기 - LINK | TEXT (머지 천천히 될예정입니다....)

### DIFF
--- a/src/components/add/LinkInput.tsx
+++ b/src/components/add/LinkInput.tsx
@@ -15,12 +15,12 @@ import PortalWrapper from '../common/PortalWrapper';
 import { FixedSpinner } from '../common/Spinner';
 
 interface LinkInputProps {
-  initalLink?: string;
+  initialLink?: string;
   openGraph: OpenGraphResponse | null;
   saveOpenGraph?: (og: OpenGraphResponse | null) => void;
 }
 
-export default function LinkInput({ initalLink, openGraph, saveOpenGraph }: LinkInputProps) {
+export default function LinkInput({ initialLink, openGraph, saveOpenGraph }: LinkInputProps) {
   const { asPath } = useInternalRouter();
   const url = useInput({ useDebounce: true });
   const {
@@ -50,8 +50,8 @@ export default function LinkInput({ initalLink, openGraph, saveOpenGraph }: Link
   };
 
   useDidUpdate(() => {
-    url.setValue(initalLink || '');
-  }, [initalLink]);
+    url.setValue(initialLink || '');
+  }, [initialLink]);
 
   useEffect(() => {
     if (!og) return;

--- a/src/components/add/LinkInput.tsx
+++ b/src/components/add/LinkInput.tsx
@@ -5,6 +5,7 @@ import LinkThumbnail from '~/components/add/LinkThumbnail';
 import { PlusIcon } from '~/components/common/icons';
 import { Input } from '~/components/common/TextField/Input';
 import { useCheckLinkAvailable } from '~/hooks/api/inspiration/useCheckLinkAvailable';
+import useDidUpdate from '~/hooks/common/useDidUpdate';
 import useInput from '~/hooks/common/useInput';
 import useInternalRouter from '~/hooks/common/useInternalRouter';
 import { useToast } from '~/store/Toast';
@@ -14,11 +15,12 @@ import PortalWrapper from '../common/PortalWrapper';
 import { FixedSpinner } from '../common/Spinner';
 
 interface LinkInputProps {
+  initalLink?: string;
   openGraph: OpenGraphResponse | null;
   saveOpenGraph?: (og: OpenGraphResponse | null) => void;
 }
 
-export default function LinkInput({ openGraph, saveOpenGraph }: LinkInputProps) {
+export default function LinkInput({ initalLink, openGraph, saveOpenGraph }: LinkInputProps) {
   const { asPath } = useInternalRouter();
   const url = useInput({ useDebounce: true });
   const {
@@ -46,6 +48,10 @@ export default function LinkInput({ openGraph, saveOpenGraph }: LinkInputProps) 
       showErrorMessage();
     }
   };
+
+  useDidUpdate(() => {
+    url.setValue(initalLink || '');
+  }, [initalLink]);
 
   useEffect(() => {
     if (!og) return;

--- a/src/hooks/common/useDataShareMessage.ts
+++ b/src/hooks/common/useDataShareMessage.ts
@@ -21,6 +21,7 @@ export function useDataShareMessage(setStateHandler: (data: string) => void) {
   // NOTE : document.addEventListener('message', handleMessage)에 event type 중 MessageEvent 존재하지 않아 선대처합니다.
   const handleMessage = (event: MessageEvent | any) => {
     const data = JSON.parse(event.data);
+    console.log(data);
     if (data.type !== SHARE_EXTENTION_MESSAGE_TYPE) return;
     setStateHandler(data.data);
   };
@@ -35,7 +36,7 @@ export function useDataShareMessage(setStateHandler: (data: string) => void) {
   useEffect(() => {
     if (!isAndroid() && !isIos() && !isMobile()) return;
     const target = isIos() ? window : document;
-    document.addEventListener('message', handleMessage);
+    target.addEventListener('message', handleMessage);
 
     return () => {
       target.removeEventListener('message', handleMessage);

--- a/src/hooks/common/useDataShareMessage.ts
+++ b/src/hooks/common/useDataShareMessage.ts
@@ -21,7 +21,6 @@ export function useDataShareMessage(setStateHandler: (data: string) => void) {
   // NOTE : document.addEventListener('message', handleMessage)에 event type 중 MessageEvent 존재하지 않아 선대처합니다.
   const handleMessage = (event: MessageEvent | any) => {
     const data = JSON.parse(event.data);
-    console.log(data);
     if (data.type !== SHARE_EXTENTION_MESSAGE_TYPE) return;
     setStateHandler(data.data);
   };

--- a/src/hooks/common/useDataShareMessage.ts
+++ b/src/hooks/common/useDataShareMessage.ts
@@ -1,0 +1,44 @@
+import { useEffect } from 'react';
+
+import useDidMount from './useDidMount';
+import { useUserAgent } from './useUserAgent';
+
+const SHARE_EXTENTION_MESSAGE_TYPE = 'YgtangAppShareData';
+const SHARE_WEB_MESSAGE_STATE = 'YgtangWebShareState';
+
+// NOTE:  webview의 onLoad, onLoadEnd, onProgress progress===1 모두 도전했지만 타이밍 맞추는 것에 실패했습니다.
+//        따라서 handshake 방법을 차용하였습니다.
+//        Native가 WebView를 엽니다.
+//        WebView useDidMount가 되었을 경우,
+//          { type: SHARE_WEB_MESSAGE_STATE, data: 'READY' }을 Native로 보냅니다.
+//          ios | android에 맞는 target에 evnet를 달아줍니다.
+//        Native는 { type: SHARE_WEB_MESSAGE_STATE, data: 'READY' }를 받아 공유할 데이터를 쏘아줍니다.
+//        WebView는 setStateHandler로 데이터를 넘겨줍니다.
+
+export function useDataShareMessage(setStateHandler: (data: string) => void) {
+  const { isAndroid, isIos, isMobile } = useUserAgent();
+
+  // NOTE : document.addEventListener('message', handleMessage)에 event type 중 MessageEvent 존재하지 않아 선대처합니다.
+  const handleMessage = (event: MessageEvent | any) => {
+    const data = JSON.parse(event.data);
+    if (data.type !== SHARE_EXTENTION_MESSAGE_TYPE) return;
+    setStateHandler(data.data);
+  };
+
+  useDidMount(() => {
+    if (!isAndroid() && !isIos() && !isMobile()) return;
+    window.ReactNativeWebView.postMessage(
+      JSON.stringify({ type: SHARE_WEB_MESSAGE_STATE, data: 'READY' })
+    );
+  });
+
+  useEffect(() => {
+    if (!isAndroid() && !isIos() && !isMobile()) return;
+    const target = isIos() ? window : document;
+    document.addEventListener('message', handleMessage);
+
+    return () => {
+      target.removeEventListener('message', handleMessage);
+    };
+  });
+}

--- a/src/hooks/common/useDataShareMessage.ts
+++ b/src/hooks/common/useDataShareMessage.ts
@@ -15,11 +15,21 @@ const SHARE_WEB_MESSAGE_STATE = 'YgtangWebShareState';
 //        Native는 { type: SHARE_WEB_MESSAGE_STATE, data: 'READY' }를 받아 공유할 데이터를 쏘아줍니다.
 //        WebView는 setStateHandler로 데이터를 넘겨줍니다.
 
+interface ShareMessageEvent {
+  data: string;
+}
+
+function isShareMessageEvent(arg: any): arg is ShareMessageEvent {
+  return arg.data !== undefined;
+}
+
 export function useDataShareMessage(setStateHandler: (data: string) => void) {
   const { isAndroid, isIos, isMobile } = useUserAgent();
 
   // NOTE : document.addEventListener('message', handleMessage)에 event type 중 MessageEvent 존재하지 않아 선대처합니다.
-  const handleMessage = (event: MessageEvent | any) => {
+  const handleMessage = (event: MessageEvent | unknown) => {
+    if (!isShareMessageEvent(event)) return;
+
     const data = JSON.parse(event.data);
     if (data.type !== SHARE_EXTENTION_MESSAGE_TYPE) return;
     setStateHandler(data.data);

--- a/src/hooks/common/useDataShareMessage.ts
+++ b/src/hooks/common/useDataShareMessage.ts
@@ -19,6 +19,12 @@ interface ShareMessageEvent {
   data: string;
 }
 
+interface ShareMessageEventData {
+  type: string;
+  data: string;
+  mimeType: string;
+}
+
 function isShareMessageEvent(arg: any): arg is ShareMessageEvent {
   return arg.data !== undefined;
 }
@@ -30,7 +36,7 @@ export function useDataShareMessage(setStateHandler: (data: string) => void) {
   const handleMessage = (event: MessageEvent | unknown) => {
     if (!isShareMessageEvent(event)) return;
 
-    const data = JSON.parse(event.data);
+    const data: ShareMessageEventData = JSON.parse(event.data);
     if (data.type !== SHARE_EXTENTION_MESSAGE_TYPE) return;
     setStateHandler(data.data);
   };

--- a/src/hooks/common/useDataShareMessage.ts
+++ b/src/hooks/common/useDataShareMessage.ts
@@ -43,6 +43,7 @@ export function useDataShareMessage(setStateHandler: (data: string) => void) {
 
   useDidMount(() => {
     if (!isAndroid() && !isIos() && !isMobile()) return;
+    if (!window.ReactNativeWebView) return;
     window.ReactNativeWebView.postMessage(
       JSON.stringify({ type: SHARE_WEB_MESSAGE_STATE, data: 'READY' })
     );

--- a/src/pages/add/link.tsx
+++ b/src/pages/add/link.tsx
@@ -28,9 +28,9 @@ export default function AddLink() {
   } = useInput({ useDebounce: true });
 
   const [openGraph, setOpenGraph] = useState<OpenGraphResponse | null>(null);
-  const [initalLink, setInitalLink] = useState('');
+  const [initialLink, setInitialLink] = useState('');
 
-  useDataShareMessage(setInitalLink);
+  useDataShareMessage(setInitialLink);
   const { fireToast } = useToast();
 
   const onMutationError = () => {
@@ -74,7 +74,7 @@ export default function AddLink() {
           <section css={addLinkTopCss}>
             <div css={contentWrapperCss}>
               <LinkInput
-                initalLink={initalLink}
+                initialLink={initialLink}
                 openGraph={openGraph}
                 saveOpenGraph={saveOpenGraph}
               />

--- a/src/pages/add/link.tsx
+++ b/src/pages/add/link.tsx
@@ -10,6 +10,7 @@ import PortalWrapper from '~/components/common/PortalWrapper';
 import { FixedSpinner } from '~/components/common/Spinner';
 import { MemoText } from '~/components/common/TextField';
 import useInspirationMutation from '~/hooks/api/inspiration/useInspirationMutation';
+import { useDataShareMessage } from '~/hooks/common/useDataShareMessage';
 import useInput from '~/hooks/common/useInput';
 import { useAppliedTags } from '~/store/AppliedTags';
 import { useToast } from '~/store/Toast';
@@ -27,6 +28,9 @@ export default function AddLink() {
   } = useInput({ useDebounce: true });
 
   const [openGraph, setOpenGraph] = useState<OpenGraphResponse | null>(null);
+  const [initalLink, setInitalLink] = useState('');
+
+  useDataShareMessage(setInitalLink);
   const { fireToast } = useToast();
 
   const onMutationError = () => {
@@ -69,7 +73,11 @@ export default function AddLink() {
         <form onSubmit={submitLink} css={formCss}>
           <section css={addLinkTopCss}>
             <div css={contentWrapperCss}>
-              <LinkInput openGraph={openGraph} saveOpenGraph={saveOpenGraph} />
+              <LinkInput
+                initalLink={initalLink}
+                openGraph={openGraph}
+                saveOpenGraph={saveOpenGraph}
+              />
             </div>
             <div css={contentWrapperCss}>
               <TagContent tags={tags} />

--- a/src/pages/add/text.tsx
+++ b/src/pages/add/text.tsx
@@ -73,7 +73,6 @@ export default function AddText() {
             <div css={contentWrapperCss}>
               <TagContent tags={tags} />
             </div>
-            <div>{sessionStorage.getItem('messageITEM')}</div>
             <div css={contentWrapperCss}>
               <MemoText
                 writable

--- a/src/pages/add/text.tsx
+++ b/src/pages/add/text.tsx
@@ -26,11 +26,7 @@ export default function AddText() {
   const { tags } = useAppliedTags(true);
   const { fireToast } = useToast();
 
-  const setInspiringTextHandler = (data: string) => {
-    inspiringText.setValue(data);
-  };
-
-  useDataShareMessage(setInspiringTextHandler);
+  useDataShareMessage(inspiringText.setValue);
 
   const onMutationError = () => {
     fireToast({ content: '영감 추가 도중 오류가 발생했습니다.' });

--- a/src/pages/add/text.tsx
+++ b/src/pages/add/text.tsx
@@ -9,6 +9,7 @@ import { FixedSpinner } from '~/components/common/Spinner';
 import { MemoText } from '~/components/common/TextField';
 import { Input } from '~/components/common/TextField/Input';
 import useInspirationMutation from '~/hooks/api/inspiration/useInspirationMutation';
+import { useDataShareMessage } from '~/hooks/common/useDataShareMessage';
 import useInput from '~/hooks/common/useInput';
 import { useAppliedTags } from '~/store/AppliedTags';
 import { useToast } from '~/store/Toast';
@@ -24,6 +25,12 @@ export default function AddText() {
   const isEmptyText = !Boolean(inspiringText.debouncedValue);
   const { tags } = useAppliedTags(true);
   const { fireToast } = useToast();
+
+  const setInspiringTextHandler = (data: string) => {
+    inspiringText.setValue(data);
+  };
+
+  useDataShareMessage(setInspiringTextHandler);
 
   const onMutationError = () => {
     fireToast({ content: '영감 추가 도중 오류가 발생했습니다.' });
@@ -70,6 +77,7 @@ export default function AddText() {
             <div css={contentWrapperCss}>
               <TagContent tags={tags} />
             </div>
+            <div>{sessionStorage.getItem('messageITEM')}</div>
             <div css={contentWrapperCss}>
               <MemoText
                 writable


### PR DESCRIPTION
## ⛳️작업 내용
### 공유된 영감을 message로 받아 State에 넣어주는 작업을 진행했습니다.

Native WebView 컴포넌트에서 onLoad, onLoadEnd, onProgress progress===1 모두 도전했지만 타이밍 맞추는 것에 실패했습니다.
그도 그럴것이 Native WebView가 web app의 mounted 시점까지 알기는 힘들것입니다.
따라서 handshake 방법을 차용하였습니다. 단계는 아래와 같습니다.
```
        1.Native가 WebView를 엽니다.
        2.WebView useDidMount가 되었을 경우,
          - { type: SHARE_WEB_MESSAGE_STATE, data: 'READY' }을 Native로 보냅니다.
          - ios | android에 맞는 target에 evnet를 달아줍니다.
        3.Native는 { type: SHARE_WEB_MESSAGE_STATE, data: 'READY' }를 받아 공유할 데이터를 쏘아줍니다.
        4.WebView는 setStateHandler로 데이터를 넘겨줍니다.
```

<!-- 작업한 사항을 간략하게 적어주세요 -->

## 📸스크린샷
https://user-images.githubusercontent.com/59507527/173603021-1ba5eb1a-a353-4b24-ba84-5de5cc61c5d2.mov
<!-- 스크린샷으로 작업한 사항을 보여주세요 -->

## ⚡️사용 방법

### useDataShareMessage 사용법
선언부에 해당하는 state setter를 넘기면됩니다.
```ts 
export default function AddText() {
  const inspiringText = useInput({ useDebounce: true });
  
  useDataShareMessage(inspiringText.setValue);
}
```
<!-- 공통 asset의 경우 사용법을 간략하게 적어봅시다 -->

## 📎레퍼런스
https://evanjin.oopy.io/react-native/webview
https://stackoverflow.com/questions/41160221/react-native-webview-postmessage-does-not-work
<!-- 참고한 레퍼런스가 있다면 기록해주세요 -->

<!--
리뷰어
혜성 : hyesungoh
도현 : ddarkr
대윤 : SenseCodeValue
은정 : positiveko
-->
