### PR TITLE
DropdownMenu 컴포넌트 개발

### DIFF
--- a/jest.setup.js
+++ b/jest.setup.js
@@ -1,4 +1,5 @@
-require('@testing-library/jest-dom');
+import { matchers } from '@emotion/jest';
+import '@testing-library/jest-dom';
 
 window.matchMedia = query => ({
   matches: false,
@@ -10,3 +11,5 @@ window.matchMedia = query => ({
   removeEventListener: jest.fn(),
   dispatchEvent: jest.fn(),
 });
+
+expect.extend(matchers);

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   },
   "devDependencies": {
     "@emotion/babel-plugin": "^11.7.2",
+    "@emotion/jest": "^11.9.3",
     "@next/bundle-analyzer": "^12.1.6",
     "@testing-library/jest-dom": "^5.16.4",
     "@testing-library/react": "^13.2.0",

--- a/src/components/common/DropdownMenu/DropdownMenu.test.tsx
+++ b/src/components/common/DropdownMenu/DropdownMenu.test.tsx
@@ -1,0 +1,61 @@
+import { fireEvent, screen } from '@testing-library/react';
+
+import { customRender } from '~/__test__/utils';
+
+import DropdownMenu from './DropdownMenu';
+
+const MOCK_LABEL = 'label';
+const MOCK_VALUES = ['foo', 'bar', 'baz'];
+const MOCK_DEFAULT_VALUE = 'foo';
+
+jest.setTimeout(30000);
+
+describe('components/common/DropdownMenu', () => {
+  it('default export로 정의되어 있어야함', () => {
+    expect(DropdownMenu).toBeDefined();
+  });
+
+  it('label props를 정상적으로 렌더링해야함', () => {
+    customRender(<DropdownMenu label={MOCK_LABEL} values={MOCK_VALUES} />);
+    expect(screen.getByText(MOCK_LABEL)).toBeInTheDocument();
+  });
+
+  it('label props를 주입하지 않을 시 label 태그가 렌더링되면 안됨', () => {
+    customRender(<DropdownMenu values={MOCK_VALUES} />);
+    expect(screen.queryByRole('label')).not.toBeInTheDocument();
+  });
+
+  it('default value가 없을 시 선택하기가 렌더링되어야함', () => {
+    customRender(<DropdownMenu values={MOCK_VALUES} />);
+    expect(screen.getByText('선택하기')).toBeInTheDocument();
+  });
+
+  it('default value가 있을 시 해당 값이 렌더링되어야함', () => {
+    customRender(<DropdownMenu values={MOCK_VALUES} defaultValue={MOCK_VALUES[0]} />);
+    expect(screen.getByText(MOCK_DEFAULT_VALUE)).toBeInTheDocument();
+  });
+
+  it('버튼을 클릭할 시 values 값들이 렌더링되어야함', () => {
+    customRender(<DropdownMenu values={MOCK_VALUES} />);
+    fireEvent.click(screen.getByRole('button'));
+    expect(screen.getByText(MOCK_VALUES[0])).toBeInTheDocument();
+    expect(screen.getByText(MOCK_VALUES[1])).toBeInTheDocument();
+    expect(screen.getByText(MOCK_VALUES[2])).toBeInTheDocument();
+  });
+
+  it('버튼을 클릭한 후 요소를 클릭할 시, values 값들이 보이면 안되며 선택한 값만 보여야함', async () => {
+    customRender(<DropdownMenu values={MOCK_VALUES} />);
+    fireEvent.click(screen.getByRole('button'));
+    fireEvent.click(screen.getByText(MOCK_VALUES[0]));
+
+    await new Promise(r => setTimeout(r, 1000));
+    expect(screen.getByRole('button').innerHTML).toContain(MOCK_VALUES[0]);
+    expect(screen.queryByText(MOCK_VALUES[1])).not.toBeInTheDocument();
+    expect(screen.queryByText(MOCK_VALUES[2])).not.toBeInTheDocument();
+  });
+
+  it('select 태그는 렌더링되지 않아야함', () => {
+    customRender(<DropdownMenu values={MOCK_VALUES} />);
+    expect(screen.getByTestId('select')).toHaveStyleRule('display', 'none');
+  });
+});

--- a/src/components/common/DropdownMenu/DropdownMenu.tsx
+++ b/src/components/common/DropdownMenu/DropdownMenu.tsx
@@ -1,0 +1,108 @@
+/** @jsxImportSource @emotion/react */
+
+import { forwardRef, Ref, useState } from 'react';
+import { css, Theme, useTheme } from '@emotion/react';
+
+import Menu from '~/components/my/Menu';
+import useToggle from '~/hooks/common/useToggle';
+
+import BottomSheetModal from '../BottomSheetModal';
+import { CheckIcon, ChevronIcon } from '../icons';
+
+interface DropdownMenuProps<T extends string[]> {
+  label?: string;
+  values: [...T];
+  defaultValue?: T[number];
+}
+
+const DropdownMenu = forwardRef(function DropdownMenu<T extends string[]>(
+  { label, values, defaultValue }: DropdownMenuProps<T>,
+  ref: Ref<HTMLSelectElement>
+) {
+  const theme = useTheme();
+  const [value, setValue] = useState<string | null>(defaultValue ?? null);
+  const [isOpen, toggleIsOpen] = useToggle(false);
+
+  const onClickOption = (eachValue: string) => {
+    toggleIsOpen();
+    setValue(eachValue);
+  };
+
+  return (
+    <div css={wrapperCss}>
+      {label && (
+        <label role="label" css={labelCss}>
+          {label}
+        </label>
+      )}
+
+      <select
+        data-testid="select"
+        value={value ? value : undefined}
+        disabled
+        css={selectCss}
+        ref={ref}
+      >
+        <option />
+        {values.map(eachValue => (
+          <option key={eachValue} value={eachValue} />
+        ))}
+      </select>
+
+      <button onClick={toggleIsOpen} css={buttonCss}>
+        {value ?? '선택하기'}
+
+        <ChevronIcon direction="down" />
+      </button>
+
+      <BottomSheetModal isShowing={isOpen} onClose={toggleIsOpen}>
+        <ul css={dropdownUlCss}>
+          {values.map(eachValue => (
+            <Menu
+              key={eachValue}
+              onClick={() => onClickOption(eachValue)}
+              label={eachValue}
+              rightElement={
+                eachValue === value ? <CheckIcon color={theme.color.primary} /> : undefined
+              }
+            />
+          ))}
+        </ul>
+      </BottomSheetModal>
+    </div>
+  );
+});
+
+export default DropdownMenu;
+
+const wrapperCss = css`
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+`;
+
+const labelCss = (theme: Theme) => css`
+  color: ${theme.color.gray05};
+  margin-bottom: 6px;
+  font-size: 14px;
+`;
+
+const selectCss = css`
+  display: none;
+`;
+
+const buttonCss = (theme: Theme) => css`
+  width: 100%;
+  height: 52px;
+  color: ${theme.color.gray05};
+  background-color: ${theme.color.gray01};
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0 13px;
+  border-radius: ${theme.borderRadius.default};
+`;
+
+const dropdownUlCss = css`
+  padding: 20px 16px 40px 16px;
+`;

--- a/src/components/common/DropdownMenu/DropdownMenu.tsx
+++ b/src/components/common/DropdownMenu/DropdownMenu.tsx
@@ -20,12 +20,12 @@ const DropdownMenu = forwardRef(function DropdownMenu<T extends string[]>(
   ref: Ref<HTMLSelectElement>
 ) {
   const theme = useTheme();
-  const [value, setValue] = useState<string | null>(defaultValue ?? null);
+  const [value, setValue] = useState<string | undefined>(defaultValue ?? undefined);
   const [isOpen, toggleIsOpen] = useToggle(false);
 
   const onClickOption = (eachValue: string) => {
-    toggleIsOpen();
     setValue(eachValue);
+    toggleIsOpen();
   };
 
   return (
@@ -36,13 +36,7 @@ const DropdownMenu = forwardRef(function DropdownMenu<T extends string[]>(
         </label>
       )}
 
-      <select
-        data-testid="select"
-        value={value ? value : undefined}
-        disabled
-        css={selectCss}
-        ref={ref}
-      >
+      <select data-testid="select" value={value} disabled css={selectCss} ref={ref}>
         <option />
         {values.map(eachValue => (
           <option key={eachValue} value={eachValue} />

--- a/src/components/common/DropdownMenu/index.test.tsx
+++ b/src/components/common/DropdownMenu/index.test.tsx
@@ -1,0 +1,7 @@
+import Default from './index';
+
+describe('components/common/DropdownMenu/index', () => {
+  it('default export로 정의되어 있어야함', () => {
+    expect(Default).toBeDefined();
+  });
+});

--- a/src/components/common/DropdownMenu/index.tsx
+++ b/src/components/common/DropdownMenu/index.tsx
@@ -1,0 +1,1 @@
+export { default } from './DropdownMenu';

--- a/src/constants/common.ts
+++ b/src/constants/common.ts
@@ -4,6 +4,7 @@ export const PUBLIC_ROUTES = [
   '/signup',
   '/signup/sent-email',
   '/signup/email-verified',
+  '/signup/information',
   '/onboard',
   '/password/sent-email',
   '/password/verified',

--- a/src/hooks/common/useInternalRouter.ts
+++ b/src/hooks/common/useInternalRouter.ts
@@ -20,6 +20,7 @@ export type RouterPathType =
   | '/signup'
   | '/signup/sent-email'
   | '/signup/email-verified'
+  | '/signup/information'
   | '/password';
 
 export default function useInternalRouter() {

--- a/src/pages/signup/information.tsx
+++ b/src/pages/signup/information.tsx
@@ -1,0 +1,3 @@
+export default function Information() {
+  return <main></main>;
+}

--- a/src/pages/signup/information.tsx
+++ b/src/pages/signup/information.tsx
@@ -1,3 +1,0 @@
-export default function Information() {
-  return <main></main>;
-}

--- a/yarn.lock
+++ b/yarn.lock
@@ -392,6 +392,14 @@
     "@emotion/weak-memoize" "^0.2.5"
     stylis "4.0.13"
 
+"@emotion/css-prettifier@^1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@emotion/css-prettifier/-/css-prettifier-1.0.1.tgz#a3ce1667398e83701f52ec43938208faeef2e0a5"
+  integrity sha512-cA9Dtol47mtvWKasPC+8tkh2DS0wBkX0MMHKieXGSkGyx079V7yFY85KC0pPalcIy+vi0LbMR9DNyiJBqYgJ1Q==
+  dependencies:
+    "@emotion/memoize" "^0.7.4"
+    stylis "4.0.13"
+
 "@emotion/hash@^0.8.0":
   version "0.8.0"
   resolved "https://registry.npmjs.org/@emotion/hash/-/hash-0.8.0.tgz"
@@ -403,6 +411,17 @@
   integrity sha512-u5WtneEAr5IDG2Wv65yhunPSMLIpuKsbuOktRojfrEiEvRyC85LgPMZI63cr7NUqT8ZIGdSVg8ZKGxIug4lXcA==
   dependencies:
     "@emotion/memoize" "0.7.4"
+
+"@emotion/jest@^11.9.3":
+  version "11.9.3"
+  resolved "https://registry.yarnpkg.com/@emotion/jest/-/jest-11.9.3.tgz#24a392d24e9af1f91bd1297ab1e53f069f9ca47c"
+  integrity sha512-fDfZc1ydjjJ+2IDAK+rP+rm469I4u5cIkN3zmGYf0CBW9TLrtM9u9kke3s+i5/M2UpcqLDvtal0EyPBR0A8EWg==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@emotion/css-prettifier" "^1.0.1"
+    chalk "^4.1.0"
+    specificity "^0.4.1"
+    stylis "4.0.13"
 
 "@emotion/memoize@0.7.4":
   version "0.7.4"
@@ -6207,6 +6226,11 @@ source-map@^0.6.0, source-map@^0.6.1, source-map@~0.6.1:
   version "0.6.1"
   resolved "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz"
   integrity sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==
+
+specificity@^0.4.1:
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/specificity/-/specificity-0.4.1.tgz#aab5e645012db08ba182e151165738d00887b019"
+  integrity sha512-1klA3Gi5PD1Wv9Q0wUoOQN1IWAuPu0D1U03ThXTr0cJ20+/iq2tHSDnK7Kk/0LXJ1ztUB2/1Os0wKmfyNgUQfg==
 
 split-string@^3.0.1, split-string@^3.0.2:
   version "3.1.0"


### PR DESCRIPTION
## ⛳️작업 내용

- `/signup/information` route를 public route에 등록했어요

- test 환경에서 css style을 확인할 수 있도록 `@emotion/jest` 설치 및 설정을 했어요

- DropdownMenu 컴포넌트를 개발했어요

- 현재 선택한 값을 사용하는 곳에서 알 수 있도록 하는 방법에 대해 많이 고민해봤어요
  - 크게 생각한 방법은 `state, setState`를 props로 받는 방법과 현재 적용한 `forwardRef` 방법이에요.
  - 사용하는 곳에서 setStating을 하는 것이 불편할 것 같은 판단 + select 태그에 대한 ref 사용이 사용하는 입장에서 더욱 직관적일 것 같아서 이렇게 적용해봤어요
  - 다른 방법이나 피드백 완전 환영입니다 ~!

## 📸스크린샷


https://user-images.githubusercontent.com/26461307/174295461-d010316e-56c5-43de-bd7f-aa17bb977123.mov



## ⚡️사용 방법

```jsx
const MOCK_LABEL = 'label';
const MOCK_VALUES = ['foo', 'bar', 'baz'];

// 라벨과 함께
<DropdownMenu label={MOCK_LABEL} values={MOCK_VALUES} />

// 기본값과 함께
<DropdownMenu values={MOCK_VALUES} defaultValue={MOCK_VALUES[0]} />
```

```jsx
import { useRef } from 'react';

import DropdownMenu from '~/components/common/DropdownMenu';

export default function Iii() {
  const ref = useRef<HTMLSelectElement>(null);

  return (
    <div>
      <button
        onClick={() => {
          console.log(ref.current?.value);
        }}
      >
       check
      </button>
      <DropdownMenu values={['a', 'b', 'c']} ref={ref} />
    </div>
  );
}

```

## 📎레퍼런스

- emotion css jest 환경 스택오버플로우

https://stackoverflow.com/questions/72058933/testing-library-with-emotion-css

- `DropdownMenu`에서 사용된 튜플 타입 스택오버플로우

https://stackoverflow.com/questions/72619020/typescript-create-dynamicaly-union-type-from-same-interface-props


closed #419 
