### PR TITLE
회원가입 시 추가 정보 플로우 개발 

### DIFF
--- a/src/components/common/DropdownMenu/DropdownMenu.test.tsx
+++ b/src/components/common/DropdownMenu/DropdownMenu.test.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react';
 import { fireEvent, screen } from '@testing-library/react';
 
 import { customRender } from '~/__test__/utils';
@@ -16,27 +17,49 @@ describe('components/common/DropdownMenu', () => {
   });
 
   it('label props를 정상적으로 렌더링해야함', () => {
-    customRender(<DropdownMenu label={MOCK_LABEL} values={MOCK_VALUES} />);
+    function Wrapper() {
+      const [value, setValue] = useState<string | null>(null);
+      return (
+        <DropdownMenu label={MOCK_LABEL} values={MOCK_VALUES} value={value} setValue={setValue} />
+      );
+    }
+    customRender(<Wrapper />);
     expect(screen.getByText(MOCK_LABEL)).toBeInTheDocument();
   });
 
   it('label props를 주입하지 않을 시 label 태그가 렌더링되면 안됨', () => {
-    customRender(<DropdownMenu values={MOCK_VALUES} />);
+    function Wrapper() {
+      const [value, setValue] = useState<string | null>(null);
+      return <DropdownMenu values={MOCK_VALUES} value={value} setValue={setValue} />;
+    }
+    customRender(<Wrapper />);
     expect(screen.queryByRole('label')).not.toBeInTheDocument();
   });
 
-  it('default value가 없을 시 선택하기가 렌더링되어야함', () => {
-    customRender(<DropdownMenu values={MOCK_VALUES} />);
+  it('value가 null일 시 선택하기가 렌더링되어야함', () => {
+    function Wrapper() {
+      const [value, setValue] = useState<string | null>(null);
+      return <DropdownMenu values={MOCK_VALUES} value={value} setValue={setValue} />;
+    }
+    customRender(<Wrapper />);
     expect(screen.getByText('선택하기')).toBeInTheDocument();
   });
 
-  it('default value가 있을 시 해당 값이 렌더링되어야함', () => {
-    customRender(<DropdownMenu values={MOCK_VALUES} defaultValue={MOCK_VALUES[0]} />);
+  it('value가 있을 시 해당 값이 렌더링되어야함', () => {
+    function Wrapper() {
+      const [value, setValue] = useState<string | null>(MOCK_DEFAULT_VALUE);
+      return <DropdownMenu values={MOCK_VALUES} value={value} setValue={setValue} />;
+    }
+    customRender(<Wrapper />);
     expect(screen.getByText(MOCK_DEFAULT_VALUE)).toBeInTheDocument();
   });
 
   it('버튼을 클릭할 시 values 값들이 렌더링되어야함', () => {
-    customRender(<DropdownMenu values={MOCK_VALUES} />);
+    function Wrapper() {
+      const [value, setValue] = useState<string | null>(null);
+      return <DropdownMenu values={MOCK_VALUES} value={value} setValue={setValue} />;
+    }
+    customRender(<Wrapper />);
     fireEvent.click(screen.getByRole('button'));
     expect(screen.getByText(MOCK_VALUES[0])).toBeInTheDocument();
     expect(screen.getByText(MOCK_VALUES[1])).toBeInTheDocument();
@@ -44,7 +67,11 @@ describe('components/common/DropdownMenu', () => {
   });
 
   it('버튼을 클릭한 후 요소를 클릭할 시, values 값들이 보이면 안되며 선택한 값만 보여야함', async () => {
-    customRender(<DropdownMenu values={MOCK_VALUES} />);
+    function Wrapper() {
+      const [value, setValue] = useState<string | null>(null);
+      return <DropdownMenu values={MOCK_VALUES} value={value} setValue={setValue} />;
+    }
+    customRender(<Wrapper />);
     fireEvent.click(screen.getByRole('button'));
     fireEvent.click(screen.getByText(MOCK_VALUES[0]));
 
@@ -52,10 +79,5 @@ describe('components/common/DropdownMenu', () => {
     expect(screen.getByRole('button').innerHTML).toContain(MOCK_VALUES[0]);
     expect(screen.queryByText(MOCK_VALUES[1])).not.toBeInTheDocument();
     expect(screen.queryByText(MOCK_VALUES[2])).not.toBeInTheDocument();
-  });
-
-  it('select 태그는 렌더링되지 않아야함', () => {
-    customRender(<DropdownMenu values={MOCK_VALUES} />);
-    expect(screen.getByTestId('select')).toHaveStyleRule('display', 'none');
   });
 });

--- a/src/components/common/DropdownMenu/DropdownMenu.tsx
+++ b/src/components/common/DropdownMenu/DropdownMenu.tsx
@@ -9,14 +9,19 @@ import useToggle from '~/hooks/common/useToggle';
 import BottomSheetModal from '../BottomSheetModal';
 import { CheckIcon, ChevronIcon } from '../icons';
 
-interface DropdownMenuProps {
+interface DropdownMenuProps<T extends readonly string[]> {
   label?: string;
-  values: string[];
+  values: string[] | T;
   value: string | null;
-  setValue: Dispatch<SetStateAction<string | null>>;
+  setValue: Dispatch<SetStateAction<string | null>> | Dispatch<SetStateAction<T[number] | null>>;
 }
 
-export default function DropdownMenu({ label, values, value, setValue }: DropdownMenuProps) {
+export default function DropdownMenu<T extends readonly string[]>({
+  label,
+  values,
+  value,
+  setValue,
+}: DropdownMenuProps<T>) {
   const theme = useTheme();
   const [isOpen, toggleIsOpen] = useToggle(false);
 

--- a/src/components/common/DropdownMenu/DropdownMenu.tsx
+++ b/src/components/common/DropdownMenu/DropdownMenu.tsx
@@ -1,6 +1,6 @@
 /** @jsxImportSource @emotion/react */
 
-import { forwardRef, Ref, useState } from 'react';
+import { Dispatch, SetStateAction } from 'react';
 import { css, Theme, useTheme } from '@emotion/react';
 
 import Menu from '~/components/my/Menu';
@@ -9,18 +9,15 @@ import useToggle from '~/hooks/common/useToggle';
 import BottomSheetModal from '../BottomSheetModal';
 import { CheckIcon, ChevronIcon } from '../icons';
 
-interface DropdownMenuProps<T extends string[]> {
+interface DropdownMenuProps {
   label?: string;
-  values: [...T];
-  defaultValue?: T[number];
+  values: string[];
+  value: string | null;
+  setValue: Dispatch<SetStateAction<string | null>>;
 }
 
-const DropdownMenu = forwardRef(function DropdownMenu<T extends string[]>(
-  { label, values, defaultValue }: DropdownMenuProps<T>,
-  ref: Ref<HTMLSelectElement>
-) {
+export default function DropdownMenu({ label, values, value, setValue }: DropdownMenuProps) {
   const theme = useTheme();
-  const [value, setValue] = useState<string | undefined>(defaultValue ?? undefined);
   const [isOpen, toggleIsOpen] = useToggle(false);
 
   const onClickOption = (eachValue: string) => {
@@ -35,13 +32,6 @@ const DropdownMenu = forwardRef(function DropdownMenu<T extends string[]>(
           {label}
         </label>
       )}
-
-      <select data-testid="select" value={value} disabled css={selectCss} ref={ref}>
-        <option />
-        {values.map(eachValue => (
-          <option key={eachValue} value={eachValue} />
-        ))}
-      </select>
 
       <button onClick={toggleIsOpen} css={buttonCss}>
         {value ?? '선택하기'}
@@ -65,9 +55,7 @@ const DropdownMenu = forwardRef(function DropdownMenu<T extends string[]>(
       </BottomSheetModal>
     </div>
   );
-});
-
-export default DropdownMenu;
+}
 
 const wrapperCss = css`
   display: flex;
@@ -79,10 +67,6 @@ const labelCss = (theme: Theme) => css`
   color: ${theme.color.gray05};
   margin-bottom: 6px;
   font-size: 14px;
-`;
-
-const selectCss = css`
-  display: none;
 `;
 
 const buttonCss = (theme: Theme) => css`

--- a/src/hooks/api/sign-up/usePatchExtraInformation.ts
+++ b/src/hooks/api/sign-up/usePatchExtraInformation.ts
@@ -13,6 +13,7 @@ interface ExtraInformationParams {
 
 export default function usePatchExtraInformation() {
   const { fireToast } = useToast();
+  // NOTE: 회원가입 중단 방법 대응 후, 이메일 확인 로직 변경될 수 있음
   const { userInformation } = useUserInformation();
   const router = useInternalRouter();
 

--- a/src/hooks/api/sign-up/usePatchExtraInformation.ts
+++ b/src/hooks/api/sign-up/usePatchExtraInformation.ts
@@ -1,11 +1,10 @@
 import { useMutation } from 'react-query';
 
-import useInternalRouter from '~/hooks/common/useInternalRouter';
 import { patch } from '~/libs/api/client';
 import { useToast } from '~/store/Toast';
-import { useUserInformation } from '~/store/UserInformation';
 
-interface ExtraInformationParams {
+export interface ExtraInformationParams {
+  email: string;
   age: string;
   job: string;
   gender: string;
@@ -13,17 +12,11 @@ interface ExtraInformationParams {
 
 export default function usePatchExtraInformation() {
   const { fireToast } = useToast();
-  // NOTE: 회원가입 중단 방법 대응 후, 이메일 확인 로직 변경될 수 있음
-  const { userInformation } = useUserInformation();
-  const router = useInternalRouter();
 
   const mutation = useMutation<unknown, { message?: string }, ExtraInformationParams>(
     (data: ExtraInformationParams) =>
-      patch(`/v1/signup/extra-informations?email=${userInformation.email}`, data),
+      patch(`/v1/signup/extra-informations?email=${data.email}`, data),
     {
-      onSuccess: () => {
-        router.push('/');
-      },
       onError: error => {
         fireToast({
           content: error.message ?? '문제가 발생했습니다. 다시 시도해주세요.',

--- a/src/hooks/api/sign-up/usePatchExtraInformation.ts
+++ b/src/hooks/api/sign-up/usePatchExtraInformation.ts
@@ -1,0 +1,36 @@
+import { useMutation } from 'react-query';
+
+import useInternalRouter from '~/hooks/common/useInternalRouter';
+import { patch } from '~/libs/api/client';
+import { useToast } from '~/store/Toast';
+import { useUserInformation } from '~/store/UserInformation';
+
+interface ExtraInformationParams {
+  age: string;
+  job: string;
+  gender: string;
+}
+
+export default function usePatchExtraInformation() {
+  const { fireToast } = useToast();
+  const { userInformation } = useUserInformation();
+  const router = useInternalRouter();
+
+  const mutation = useMutation<unknown, { message?: string }, ExtraInformationParams>(
+    (data: ExtraInformationParams) =>
+      patch(`/v1/signup/extra-informations?email=${userInformation.email}`, data),
+    {
+      onSuccess: () => {
+        router.push('/');
+      },
+      onError: error => {
+        fireToast({
+          content: error.message ?? '문제가 발생했습니다. 다시 시도해주세요.',
+          duration: 3500,
+        });
+      },
+    }
+  );
+
+  return mutation;
+}

--- a/src/hooks/api/sign-up/useSignupMutation.ts
+++ b/src/hooks/api/sign-up/useSignupMutation.ts
@@ -48,7 +48,7 @@ export default function useSignupMutation() {
         });
 
         userLogin({ accessToken, refreshToken });
-        router.push('/');
+        router.push('/signup/information');
       },
       onError: error => {
         fireToast({

--- a/src/hooks/api/sign-up/useSignupMutation.ts
+++ b/src/hooks/api/sign-up/useSignupMutation.ts
@@ -47,6 +47,7 @@ export default function useSignupMutation() {
           category: '이메일 인증 후 회원가입 화면',
         });
 
+        // TODO: 회원가입 로직 중단 시 대응 방법 강구
         userLogin({ accessToken, refreshToken });
         router.push('/signup/information');
       },

--- a/src/hooks/api/sign-up/useSignupMutation.ts
+++ b/src/hooks/api/sign-up/useSignupMutation.ts
@@ -1,10 +1,7 @@
 import { useMutation } from 'react-query';
 
-import useInternalRouter from '~/hooks/common/useInternalRouter';
-import { useUser } from '~/hooks/common/useUser';
 import { post } from '~/libs/api/client';
 import { useToast } from '~/store/Toast';
-import { recordEvent } from '~/utils/analytics';
 
 interface SignupMutationParams {
   email: string;
@@ -30,27 +27,10 @@ interface SignupMutationResponse {
  */
 export default function useSignupMutation() {
   const { fireToast } = useToast();
-  const router = useInternalRouter();
-  const { userLogin } = useUser();
 
   const mutation = useMutation<SignupMutationResponse, { message?: string }, SignupMutationParams>(
     (data: SignupMutationParams) => post<SignupMutationResponse>(`/v1/signup`, data),
     {
-      onSuccess: data => {
-        const {
-          data: { accessToken, refreshToken },
-        } = data;
-
-        recordEvent({
-          action: 'Signup',
-          value: '회원 가입 완료',
-          category: '이메일 인증 후 회원가입 화면',
-        });
-
-        // TODO: 회원가입 로직 중단 시 대응 방법 강구
-        userLogin({ accessToken, refreshToken });
-        router.push('/signup/information');
-      },
       onError: error => {
         fireToast({
           content: error.message ?? '문제가 발생했습니다. 다시 시도해주세요.',

--- a/src/hooks/common/useInternalRouter.ts
+++ b/src/hooks/common/useInternalRouter.ts
@@ -1,4 +1,3 @@
-import { useMemo } from 'react';
 import { useRouter } from 'next/router';
 import { UrlObject } from 'url';
 
@@ -26,21 +25,19 @@ export type RouterPathType =
 export default function useInternalRouter() {
   const router = useRouter();
 
-  return useMemo(() => {
-    return {
-      ...router,
-      push(path: RouterPathType, as?: UrlObject | string, options?: TransitionOptions) {
-        router.push(path, as, options);
-      },
-      scrollPreventedPush(
-        path: RouterPathType,
-        as?: UrlObject | string,
-        options?: Omit<TransitionOptions, 'scroll'>
-      ) {
-        router.push(path, as, { ...options, scroll: false });
-      },
-    };
-  }, [router]);
+  return {
+    ...router,
+    push(path: RouterPathType, as?: UrlObject | string, options?: TransitionOptions) {
+      router.push(path, as, options);
+    },
+    scrollPreventedPush(
+      path: RouterPathType,
+      as?: UrlObject | string,
+      options?: Omit<TransitionOptions, 'scroll'>
+    ) {
+      router.push(path, as, { ...options, scroll: false });
+    },
+  };
 }
 
 interface TransitionOptions {

--- a/src/libs/api/client.ts
+++ b/src/libs/api/client.ts
@@ -38,6 +38,10 @@ export function put<T>(...args: Parameters<typeof instance.put>) {
   return instance.put<T, T>(...args);
 }
 
+export function patch<T>(...args: Parameters<typeof instance.patch>) {
+  return instance.patch<T, T>(...args);
+}
+
 export function del<T>(...args: Parameters<typeof instance.delete>) {
   return instance.delete<T, T>(...args);
 }

--- a/src/pages/signup/email-verified.tsx
+++ b/src/pages/signup/email-verified.tsx
@@ -156,7 +156,7 @@ export default function SignUpEmailVerified() {
             </div>
           </fieldset>
           <CTABottomButton type={'submit'} disabled={signupLoading}>
-            Start Tang!
+            다음
           </CTABottomButton>
         </form>
       </article>

--- a/src/pages/signup/email-verified.tsx
+++ b/src/pages/signup/email-verified.tsx
@@ -100,7 +100,7 @@ export default function SignUpEmailVerified() {
     >
       <article css={containerCss}>
         <NavigationBar title={'회원가입'} />
-        <p css={introTextWrapper}>마지막 단계입니다!</p>
+        <p css={introTextWrapper}>거의 다 왔습니다!</p>
         <form css={formCss} onSubmit={handleSignupSubmit}>
           <fieldset css={fieldSetCss}>
             <TextField

--- a/src/pages/signup/email-verified.tsx
+++ b/src/pages/signup/email-verified.tsx
@@ -1,24 +1,23 @@
 import { FormEvent, useState } from 'react';
-import { useRouter } from 'next/router';
+import Router from 'next/router';
 import { css, Theme } from '@emotion/react';
 
 import { CTABottomButton } from '~/components/common/Button';
 import CheckList from '~/components/common/CheckList';
-import LoadingHandler from '~/components/common/LoadingHandler';
 import NavigationBar from '~/components/common/NavigationBar';
-import { FixedSpinner } from '~/components/common/Spinner';
 import TextField from '~/components/common/TextField';
 import { POLICY_URL } from '~/constants/common';
-import useSignupMutation from '~/hooks/api/sign-up/useSignupMutation';
 import useDidUpdate from '~/hooks/common/useDidUpdate';
 import useInput from '~/hooks/common/useInput';
+import useRouterQuery from '~/hooks/common/useRouterQuery';
 import useToggle from '~/hooks/common/useToggle';
+import useSignupUser from '~/store/Signup/useSignupUser';
 import { useToast } from '~/store/Toast';
 import { validator } from '~/utils/validator';
 
 export default function SignUpEmailVerified() {
   const { fireToast } = useToast();
-  const { query } = useRouter();
+  const queryEmail = useRouterQuery('email', String);
 
   const nickname = useInput({ useDebounce: true });
   const password = useInput({ useDebounce: true });
@@ -29,12 +28,12 @@ export default function SignUpEmailVerified() {
 
   const { checkTerms, toggleCheckTerms, checkPrivacy, toggleCheckPrivacy } = useInternalCheckList();
 
-  const { mutate: signupMutate, isLoading: signupLoading } = useSignupMutation();
+  const { setSignupUser } = useSignupUser();
 
   const handleSignupSubmit = (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault();
 
-    if (!validator({ type: 'email', value: query.email as string })) {
+    if (!validator({ type: 'email', value: queryEmail as string })) {
       return fireToast({
         content: '올바르지 않은 이메일입니다. 처음부터 다시 시도해주세요',
         duration: 3500,
@@ -49,14 +48,17 @@ export default function SignUpEmailVerified() {
       return fireToast({ content: '동의하지 않은 항목을 확인해주세요.' });
     }
 
-    signupMutate({
-      email: query.email as string,
+    setSignupUser({
       nickName: nickname.value.trim(),
       password: password.value,
       confirmPassword: passwordRepeat.value,
     });
+
+    // NOTE: 이렇게 작성하지 않으면 router.push가 되지않는 이슈
+    Router.push({ pathname: '/signup/information', query: { email: queryEmail } });
   };
 
+  // NOTE: 닉네임 에러 메세지 설정 이펙트
   useDidUpdate(() => {
     if (nickname.debouncedValue.trim().length >= 4 && nickname.debouncedValue.trim().length <= 20) {
       setNicknameError('');
@@ -65,6 +67,7 @@ export default function SignUpEmailVerified() {
     }
   }, [nickname.debouncedValue]);
 
+  // NOTE: 비밀번호 에러 메세지 설정 이펙트
   useDidUpdate(() => {
     if (password.debouncedValue.length >= 6) {
       if (
@@ -82,6 +85,7 @@ export default function SignUpEmailVerified() {
     }
   }, [password.debouncedValue]);
 
+  // NOTE: 비밀번호 확인 에러 메세지 설정 이펙트
   useDidUpdate(() => {
     if (
       passwordRepeat.debouncedValue.length > 0 &&
@@ -94,73 +98,66 @@ export default function SignUpEmailVerified() {
   }, [passwordRepeat.debouncedValue]);
 
   return (
-    <LoadingHandler
-      isLoading={!query || !Boolean(query.email) || query.email === undefined}
-      loadingComponent={<FixedSpinner />}
-    >
-      <article css={containerCss}>
-        <NavigationBar title={'회원가입'} />
-        <p css={introTextWrapper}>거의 다 왔습니다!</p>
-        <form css={formCss} onSubmit={handleSignupSubmit}>
-          <fieldset css={fieldSetCss}>
-            <TextField
-              label={'닉네임'}
-              placeholder={'닉네임을 입력해주세요'}
-              feedback={nickname.debouncedValue !== '' ? nicknameError || <>&nbsp;</> : <>&nbsp;</>}
-              isSuccess={nickname.debouncedValue.length > 0 && nicknameError === ''}
-              value={nickname.value}
-              onChange={nickname.onChange}
-              required
-            />
-            <TextField
-              type="password"
-              label={'비밀번호'}
-              placeholder={'영문, 숫자 포함 6자 이상의 비밀번호'}
-              feedback={password.debouncedValue !== '' ? passwordError || <>&nbsp;</> : <>&nbsp;</>}
-              isSuccess={password.debouncedValue.length > 0 && passwordError === ''}
-              value={password.value}
-              onChange={password.onChange}
-              required
-            />
-            <TextField
-              type="password"
-              label={'비밀번호 확인'}
-              placeholder={'영문, 숫자 포함 6자 이상의 비밀번호'}
-              feedback={
-                passwordRepeat.debouncedValue !== '' ? (
-                  passwordRepeatError || <>&nbsp;</>
-                ) : (
-                  <>&nbsp;</>
-                )
-              }
-              isSuccess={passwordRepeat.debouncedValue.length > 0 && passwordRepeatError === ''}
-              value={passwordRepeat.value}
-              onChange={passwordRepeat.onChange}
-              required
-            />
-            <div css={checkListWrapperCss}>
-              <CheckList
-                isChecked={checkTerms}
-                externalHref={POLICY_URL.TOS}
-                onToggle={() => toggleCheckTerms()}
-              >
-                (필수) 서비스 이용약관에 동의
-              </CheckList>
-              <CheckList
-                isChecked={checkPrivacy}
-                externalHref={POLICY_URL.PRIVACY}
-                onToggle={() => toggleCheckPrivacy()}
-              >
-                (필수) 개인정보 수집 이용에 동의
-              </CheckList>
-            </div>
-          </fieldset>
-          <CTABottomButton type={'submit'} disabled={signupLoading}>
-            다음
-          </CTABottomButton>
-        </form>
-      </article>
-    </LoadingHandler>
+    <article css={containerCss}>
+      <NavigationBar title={'회원가입'} />
+      <p css={introTextWrapper}>거의 다 왔습니다!</p>
+      <form css={formCss} onSubmit={handleSignupSubmit}>
+        <fieldset css={fieldSetCss}>
+          <TextField
+            label={'닉네임'}
+            placeholder={'닉네임을 입력해주세요'}
+            feedback={nickname.debouncedValue !== '' ? nicknameError || <>&nbsp;</> : <>&nbsp;</>}
+            isSuccess={nickname.debouncedValue.length > 0 && nicknameError === ''}
+            value={nickname.value}
+            onChange={nickname.onChange}
+            required
+          />
+          <TextField
+            type="password"
+            label={'비밀번호'}
+            placeholder={'영문, 숫자 포함 6자 이상의 비밀번호'}
+            feedback={password.debouncedValue !== '' ? passwordError || <>&nbsp;</> : <>&nbsp;</>}
+            isSuccess={password.debouncedValue.length > 0 && passwordError === ''}
+            value={password.value}
+            onChange={password.onChange}
+            required
+          />
+          <TextField
+            type="password"
+            label={'비밀번호 확인'}
+            placeholder={'영문, 숫자 포함 6자 이상의 비밀번호'}
+            feedback={
+              passwordRepeat.debouncedValue !== '' ? (
+                passwordRepeatError || <>&nbsp;</>
+              ) : (
+                <>&nbsp;</>
+              )
+            }
+            isSuccess={passwordRepeat.debouncedValue.length > 0 && passwordRepeatError === ''}
+            value={passwordRepeat.value}
+            onChange={passwordRepeat.onChange}
+            required
+          />
+          <div css={checkListWrapperCss}>
+            <CheckList
+              isChecked={checkTerms}
+              externalHref={POLICY_URL.TOS}
+              onToggle={() => toggleCheckTerms()}
+            >
+              (필수) 서비스 이용약관에 동의
+            </CheckList>
+            <CheckList
+              isChecked={checkPrivacy}
+              externalHref={POLICY_URL.PRIVACY}
+              onToggle={() => toggleCheckPrivacy()}
+            >
+              (필수) 개인정보 수집 이용에 동의
+            </CheckList>
+          </div>
+        </fieldset>
+        <CTABottomButton type={'submit'}>다음</CTABottomButton>
+      </form>
+    </article>
   );
 }
 

--- a/src/pages/signup/index.tsx
+++ b/src/pages/signup/index.tsx
@@ -33,7 +33,7 @@ export default function Signup() {
 
   return (
     <article css={loginCss}>
-      <NavigationBar title={'회원가입'} />
+      <NavigationBar title={'회원가입'} backLink="/" />
       <div css={introCardCss}>
         <p css={introTextWrapper}>
           자주쓰는 이메일을

--- a/src/pages/signup/information.tsx
+++ b/src/pages/signup/information.tsx
@@ -1,0 +1,89 @@
+import { useState } from 'react';
+import { css, Theme } from '@emotion/react';
+
+import { CTABottomButton } from '~/components/common/Button';
+import DropdownMenu from '~/components/common/DropdownMenu';
+import NavigationBar from '~/components/common/NavigationBar';
+import usePutExtraInformation from '~/hooks/api/sign-up/usePatchExtraInformation';
+import { fullViewHeight } from '~/styles/utils';
+
+const GENDER_VALUES = ['남자', '여자', '기타'] as const;
+const GENDER_REQUEST_VALUES = { 남자: 'MALE', 여자: 'FEMALE', 기타: 'ETC' } as const;
+
+const AGE_VALUES = ['20세 미만', '20~24세', '25~29세', '30~34세', '35세 이상'] as const;
+const AGE_REQUEST_VALUES = {
+  '20세 미만': 'UNDER_20S',
+  '20~24세': 'EARLY_20S',
+  '25~29세': 'LATE_20S',
+  '30~34세': 'EARLY_30S',
+  '35세 이상': 'OLDER_35',
+} as const;
+
+const JOB_VALUES = [
+  '디자인, 예술',
+  'IT, 개발, 데이터',
+  '마케팅, 광고, 기획',
+  '경영, 비즈니스, 영업',
+  'HR, CS',
+  '교육',
+  '기타',
+] as const;
+
+export default function Information() {
+  const [gender, setGender] = useState<typeof GENDER_VALUES[number] | null>(null);
+  const [age, setAge] = useState<typeof AGE_VALUES[number] | null>(null);
+  const [job, setJob] = useState<string | null>(null);
+
+  const { mutate } = usePutExtraInformation();
+
+  const isDisabledCTAButton = !Boolean(gender && age && job);
+
+  const onClickCTA = () => {
+    if (!gender || !job || !age) return;
+
+    mutate({
+      gender: GENDER_REQUEST_VALUES[gender],
+      age: AGE_REQUEST_VALUES[age],
+      job,
+    });
+  };
+
+  return (
+    <main css={mainCss}>
+      <NavigationBar title="회원가입" />
+      <p css={introTextWrapper}>마지막 단계입니다!</p>
+      <section css={sectionCss}>
+        <DropdownMenu label="성별" values={GENDER_VALUES} value={gender} setValue={setGender} />
+        <DropdownMenu label="나이" values={AGE_VALUES} value={age} setValue={setAge} />
+        <DropdownMenu label="관심 직무" values={JOB_VALUES} value={job} setValue={setJob} />
+      </section>
+
+      <CTABottomButton onClick={onClickCTA} disabled={isDisabledCTAButton}>
+        Start Tang!
+      </CTABottomButton>
+    </main>
+  );
+}
+
+const mainCss = css`
+  height: ${fullViewHeight()};
+  display: flex;
+  flex-direction: column;
+`;
+
+const sectionCss = css`
+  flex-grow: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 36px;
+`;
+
+const introTextWrapper = (theme: Theme) => css`
+  white-space: pre;
+  font-weight: ${theme.font.weight.bold};
+  color: ${theme.color.gray05};
+  font-size: 18px;
+  line-height: 150%;
+  margin-top: 40px;
+  margin-bottom: 32px;
+`;

--- a/src/pages/signup/information.tsx
+++ b/src/pages/signup/information.tsx
@@ -85,7 +85,7 @@ export default function Information() {
             {
               onSuccess: () => {
                 clearSignupUser();
-                router.push('/');
+                router.replace('/');
               },
             }
           );

--- a/src/store/Signup/signupUserState.ts
+++ b/src/store/Signup/signupUserState.ts
@@ -1,0 +1,12 @@
+import { atom } from 'recoil';
+
+interface SignupUserState {
+  nickName: string;
+  password: string;
+  confirmPassword: string;
+}
+
+export const signupUserState = atom<SignupUserState | null>({
+  key: 'signupUserState',
+  default: null,
+});

--- a/src/store/Signup/useSignupUser.ts
+++ b/src/store/Signup/useSignupUser.ts
@@ -1,0 +1,10 @@
+import { useRecoilState, useResetRecoilState } from 'recoil';
+
+import { signupUserState } from './signupUserState';
+
+export default function useSignupUser() {
+  const [signupUser, setSignupUser] = useRecoilState(signupUserState);
+  const clearSignupUser = useResetRecoilState(signupUserState);
+
+  return { signupUser, setSignupUser, clearSignupUser };
+}


### PR DESCRIPTION
## ⛳️작업 내용

- DropdownMenu를 forwardRef를 받는 형식이 아닌, state와 setState를 props로 받는 형식으로 변경했어요
  - ref를 통해 value의 변경을 확인할 수 없을 뿐더러, 어차피 사용하는 곳에서 useRef 혹은 useState를 선언하는데 이렇게 ref를 받을 이유가 없어보였어요 ....

- signup mutation에서 route 이동을 `/signup/information`으로 하도록 변경했어요
  - 해당 route의 수정된 문구도 적용했어요

- 추가 정보를 mutate하는 hook `usePatchExtraInformation`을 개발했어요
  - 회원가입이 성공하였을 때 위 patch mutate가 진행되어야하기 때문에, `useSignupMutation`의 onSuccess 로직을 page단에 위임했어요
  - 페이지단에서 onSuccess를 사용하게 되니, 가독성이 조금 떨어지는 거 같긴해요. 
  요 부분에서는 mutate를 걷어내고 그냥 axios 요청으로 전환하는 방향도 고려해볼만한거같아요

- `/signup/information` route를 개발했어요


## 📸스크린샷
![스크린샷 2022-06-17 오후 11 38 37](https://user-images.githubusercontent.com/26461307/174320118-f8a55882-6914-4748-9d0e-3ffd9eee9777.png)

<!-- 스크린샷으로 작업한 사항을 보여주세요 -->

## ⚡️사용 방법

<!-- 공통 asset의 경우 사용법을 간략하게 적어봅시다 -->

## 🔥 이슈

- ~추가적인 정보까지 입력 후에 회원가입을 하는 로직이 구현되어 있지 않아요~
  - ~순서가 `닉네임, 비밀번호` > `추가 정보`인데 추가 정보까지 입력해야 회원가입 post를 보내는 적절한 방법이 무엇일까요?~
  > ~localStorage로 관리하여 보내기에는 비밀번호가 포함되어 있어 ...~

  - ~그래서 현재는 회원가입 후 route 이동만 추가 정보로 하는 형식으로 구현되어 있어요~
  > ~그렇기 때문에 회원가입까지 하고 추가 정보를 입력하지 않고 로그인 시 로그인이 가능해요 ㅠ~

  - ~서버측에 추가 정보를 입력한 유저인지 판별하는 api를 요구후에 이미 가입된 유저도 접속 시 push 시키도록 하는 방향도 있을 거 같아요~
   
-> **현재 회원가입에 필요한 정보를 `SignupUserState`라는 recoil atom으로 관리 후 추가 정보까지 입력했을 때 회원가입과 동시에 진행하도록 수정했어요!**

closed #431 
