### PR TITLE
영감공유하기 - IOS 영감 공유를 위한 refresh token 전송 

### DIFF
--- a/src/hooks/common/useUser/useUser.ts
+++ b/src/hooks/common/useUser/useUser.ts
@@ -5,11 +5,21 @@ import { localStorageUserTokenKeys } from '~/constants/localStorage';
 import useInternalRouter from '~/hooks/common/useInternalRouter';
 import { replaceAccessTokenForRequestInstance } from '~/libs/api/client';
 
+const SYNC_YGT_RT = 'SYNC_YGT_RT';
+
 export function useUser() {
   const [isLoaded, setIsLoaded] = useState<boolean>(false);
 
   const { push } = useInternalRouter();
   const queryClient = useQueryClient();
+
+  const postRefreshTokenReactNativeWebView = (refreshToken: string) => {
+    if (window.ReactNativeWebView) {
+      window.ReactNativeWebView.postMessage(
+        JSON.stringify({ type: SYNC_YGT_RT, data: refreshToken })
+      );
+    }
+  };
 
   /**
    * 유저 로그인 시에 사용합니다.
@@ -30,6 +40,7 @@ export function useUser() {
       replaceAccessTokenForRequestInstance(accessToken);
       localStorage.setItem(localStorageUserTokenKeys.accessToken, accessToken);
       localStorage.setItem(localStorageUserTokenKeys.refreshToken, refreshToken);
+      postRefreshTokenReactNativeWebView(refreshToken);
       queryClient.clear();
     },
     [queryClient]
@@ -38,6 +49,7 @@ export function useUser() {
   const userLogout = () => {
     localStorage.removeItem(localStorageUserTokenKeys.accessToken);
     localStorage.removeItem(localStorageUserTokenKeys.refreshToken);
+    postRefreshTokenReactNativeWebView('');
     queryClient.clear();
     push('/login');
   };


### PR DESCRIPTION
## ⛳️작업 내용
IOS일 경우, 번들 ID가 달라 webView가 localstoage를 공유하지 못했습니다.
따라서 로그인/로그아웃 할경우,
`refreshToken`를 native로 보내어 공유 storage에서 사용할 수 있도록 postMessage를 구현했습니다.
<!-- 작업한 사항을 간략하게 적어주세요 -->

## 📸스크린샷
https://user-images.githubusercontent.com/59507527/174853339-5b247494-ec3a-44e5-81e6-7d9923c4a7c8.mov
<!-- 스크린샷으로 작업한 사항을 보여주세요 -->

## ⚡️사용 방법

<!-- 공통 asset의 경우 사용법을 간략하게 적어봅시다 -->

## 📎레퍼런스
관련 APP PR : https://github.com/depromeet/ygtang-app/pull/90
<!-- 참고한 레퍼런스가 있다면 기록해주세요 -->

<!--
리뷰어
혜성 : hyesungoh
도현 : ddarkr
대윤 : SenseCodeValue
은정 : positiveko
-->
