### PR TITLE
태그 관리 - 태그 등록 모달 완료 누르면 저장되도록 변경 

### DIFF
--- a/src/components/common/NavigationBar/NavigationBar.tsx
+++ b/src/components/common/NavigationBar/NavigationBar.tsx
@@ -4,24 +4,32 @@ import { css, Theme } from '@emotion/react';
 import { IconButton } from '~/components/common/Button';
 import useInternalRouter, { RouterPathType } from '~/hooks/common/useInternalRouter';
 
-interface NavigationBarProps {
-  backLink?: RouterPathType;
-  backLinkScrollOption?: boolean;
+interface NavigationBarBaseProps {
   title?: string;
   rightElement?: ReactElement;
-  onClickBackButton?: VoidFunction;
 }
 
-export default function NavigationBar({
-  backLink,
-  backLinkScrollOption = true,
-  title,
-  rightElement,
-  onClickBackButton,
-}: NavigationBarProps) {
-  const router = useInternalRouter();
+interface NavigationBarRouterProps extends NavigationBarBaseProps {
+  backLink?: RouterPathType;
+  backLinkScrollOption?: boolean;
+  onClickBackButton: never;
+}
+interface NavigationBarCallBackProps extends NavigationBarBaseProps {
+  backLink: never;
+  backLinkScrollOption: never;
+  onClickBackButton: VoidFunction;
+}
+type NavigationBarProps =
+  | NavigationBarBaseProps
+  | NavigationBarRouterProps
+  | NavigationBarCallBackProps;
 
-  // NOTE: 1. router option을 전체적으로 받을 수 있게? 2. onClickBackButton callback을 받을 수 있게?
+export default function NavigationBar(props: NavigationBarProps) {
+  const router = useInternalRouter();
+  const { title, rightElement } = props;
+  const { onClickBackButton } = props as NavigationBarCallBackProps;
+  const { backLink, backLinkScrollOption = true } = props as NavigationBarCallBackProps;
+
   const handelOnClickBackButton = () => {
     if (onClickBackButton) {
       onClickBackButton();

--- a/src/components/common/NavigationBar/NavigationBar.tsx
+++ b/src/components/common/NavigationBar/NavigationBar.tsx
@@ -9,6 +9,7 @@ interface NavigationBarProps {
   backLinkScrollOption?: boolean;
   title?: string;
   rightElement?: ReactElement;
+  onClickBackButton?: VoidFunction;
 }
 
 export default function NavigationBar({
@@ -16,21 +17,24 @@ export default function NavigationBar({
   backLinkScrollOption = true,
   title,
   rightElement,
+  onClickBackButton,
 }: NavigationBarProps) {
   const router = useInternalRouter();
 
   // NOTE: 1. router option을 전체적으로 받을 수 있게? 2. onClickBackButton callback을 받을 수 있게?
-  const onClickBackButton = () => {
-    if (backLink) {
+  const handelOnClickBackButton = () => {
+    if (onClickBackButton) {
+      onClickBackButton();
+    } else if (backLink) {
       router.push(backLink, undefined, { scroll: backLinkScrollOption });
-      return;
+    } else {
+      router.back();
     }
-    router.back();
   };
 
   return (
     <nav css={navCss}>
-      <IconButton iconName="ChevronIcon" light onClick={onClickBackButton} />
+      <IconButton iconName="ChevronIcon" light onClick={handelOnClickBackButton} />
       {title && <h1 css={headingCss}>{title}</h1>}
       {rightElement && <>{rightElement}</>}
     </nav>

--- a/src/pages/my/tag/AddTagBottomSheet.tsx
+++ b/src/pages/my/tag/AddTagBottomSheet.tsx
@@ -19,8 +19,7 @@ export default function AddTagBottomSheet({ isShowing, onClose }: AddTagBottomSh
   const { createTag } = useTagMutation();
   const { fireToast } = useToast();
 
-  const onFormReturn = (e: React.FormEvent) => {
-    e.preventDefault();
+  const handelCreateTag = () => {
     if (!value) {
       return;
     }
@@ -31,6 +30,11 @@ export default function AddTagBottomSheet({ isShowing, onClose }: AddTagBottomSh
       },
     });
     setValue('');
+  };
+
+  const onFormReturn = (e: React.FormEvent) => {
+    e.preventDefault();
+    handelCreateTag();
   };
 
   useEffect(() => {
@@ -52,7 +56,7 @@ export default function AddTagBottomSheet({ isShowing, onClose }: AddTagBottomSh
               <GhostButton
                 size="large"
                 onClick={() => {
-                  onClose();
+                  handelCreateTag();
                 }}
               >
                 완료

--- a/src/pages/my/tag/AddTagBottomSheet.tsx
+++ b/src/pages/my/tag/AddTagBottomSheet.tsx
@@ -37,6 +37,14 @@ export default function AddTagBottomSheet({ isShowing, onClose }: AddTagBottomSh
     handelCreateTag();
   };
 
+  const onComplete = () => {
+    if (!value) {
+      onClose();
+    } else {
+      handelCreateTag();
+    }
+  };
+
   useEffect(() => {
     setValue('');
   }, [isShowing, setValue]);
@@ -59,7 +67,7 @@ export default function AddTagBottomSheet({ isShowing, onClose }: AddTagBottomSh
               <GhostButton
                 size="large"
                 onClick={() => {
-                  handelCreateTag();
+                  onComplete();
                 }}
               >
                 완료

--- a/src/pages/my/tag/AddTagBottomSheet.tsx
+++ b/src/pages/my/tag/AddTagBottomSheet.tsx
@@ -52,6 +52,9 @@ export default function AddTagBottomSheet({ isShowing, onClose }: AddTagBottomSh
         <div css={navigationBarWrapperCss}>
           <NavigationBar
             title="태그 등록"
+            onClickBackButton={() => {
+              onClose();
+            }}
             rightElement={
               <GhostButton
                 size="large"


### PR DESCRIPTION
## ⛳️작업 내용
- 태그관리 등록 모달에서 완료 누를 경우 저장 Action 수행되도롥 변경
- `NavigationBar`의 onClickBackButton를 callBack 받도록 리팩토링했습니다.
  - 해당 모달에서는 모달이 닫히는 기능을 수행해야됨으로 callBack받도록 변경했습니다.
<!-- 작업한 사항을 간략하게 적어주세요 -->

## 📸스크린샷

https://user-images.githubusercontent.com/59507527/174868273-c2d1b148-83af-4e98-be0c-1566db4fb91f.mov
<!-- 스크린샷으로 작업한 사항을 보여주세요 -->

## ⚡️사용 방법
### NavigationBar이 onClickBackButton를 감싸는 handelOnClickBackButton를 구현했습니다.
```ts
interface NavigationBarProps {
  backLink?: RouterPathType;
  backLinkScrollOption?: boolean;
  title?: string;
  rightElement?: ReactElement;
  onClickBackButton?: VoidFunction;
}

export default function NavigationBar( ...
  const handelOnClickBackButton = () => {
    if (onClickBackButton) {
      onClickBackButton();
    } else if (backLink) {
      router.push(backLink, undefined, { scroll: backLinkScrollOption });
    } else {
      router.back();
    }
  };
  return (
    <nav css={navCss}>
      <IconButton iconName="ChevronIcon" light onClick={handelOnClickBackButton} />
   ....
...
```

###  따라서사용은 있을 Router 동작이 없을 경우, onClickBackButton를 넘겨주면됩니다.
```ts
<NavigationBar
  title="태그 등록"
  onClickBackButton={() => {
    onClose();
  }}
/>
```
<!-- 공통 asset의 경우 사용법을 간략하게 적어봅시다 -->

## 📎레퍼런스

<!-- 참고한 레퍼런스가 있다면 기록해주세요 -->

<!--
리뷰어
혜성 : hyesungoh
도현 : ddarkr
대윤 : SenseCodeValue
은정 : positiveko
-->

close #446 