### PR TITLE
공유하기 - 비로그인 접근할 경우, 로그인 이후, redirect 해주기

### DIFF
--- a/src/constants/common.ts
+++ b/src/constants/common.ts
@@ -10,6 +10,8 @@ export const PUBLIC_ROUTES = [
   '/password/verified',
 ];
 
+export const ADD_ROUTES = ['/add/image', '/add/text', '/add/link'];
+
 export const IS_PRODUCTION = process.env.APP_ENV === 'production';
 
 export const COOKIE_REFRESH = 'ygt_refresh';

--- a/src/constants/sessionStorage.ts
+++ b/src/constants/sessionStorage.ts
@@ -1,0 +1,1 @@
+export const sessionStorageRedirectKey = 'ygtrdk';

--- a/src/hooks/common/useDataShareMessage.ts
+++ b/src/hooks/common/useDataShareMessage.ts
@@ -29,7 +29,9 @@ interface ShareMessageEventData {
 }
 
 function isShareMessageEvent(arg: any): arg is ShareMessageEvent {
-  return arg.data !== undefined;
+  if (arg.data === undefined || typeof arg.data !== 'string') return false;
+  const messgaeType = JSON.parse(arg.data)?.type;
+  return messgaeType ? messgaeType === SHARE_EXTENTION_MESSAGE_TYPE : false;
 }
 
 interface ImgShareMessageProps {
@@ -51,9 +53,8 @@ export function useDataShareMessage({
   // NOTE : document.addEventListener('message', handleMessage)에 event type 중 MessageEvent 존재하지 않아 선대처합니다.
   const handleMessage = async (event: MessageEvent | unknown) => {
     if (!isShareMessageEvent(event)) return;
-
     const data: ShareMessageEventData = JSON.parse(event.data);
-    if (data.type !== SHARE_EXTENTION_MESSAGE_TYPE) return;
+
     if (type === 'IMAGE') {
       setStateHandler({ blob: await base64ToBlob(data.data, data.mimeType), base64: data.data });
     } else {

--- a/src/hooks/common/useLoginRedirect.ts
+++ b/src/hooks/common/useLoginRedirect.ts
@@ -1,0 +1,23 @@
+import { useRouter } from 'next/router';
+
+import { sessionStorageRedirectKey } from '~/constants/sessionStorage';
+
+export function useLoginRedirect() {
+  const router = useRouter();
+  const getRedirect = (): string | null => {
+    return sessionStorage.getItem(sessionStorageRedirectKey);
+  };
+
+  const setRedirect = (path: string) => {
+    sessionStorage.setItem(sessionStorageRedirectKey, path);
+  };
+
+  const goRedirect = () => {
+    const redirect = getRedirect();
+    if (!redirect) return;
+    router.replace(redirect);
+    sessionStorage.removeItem(sessionStorageRedirectKey);
+  };
+
+  return { getRedirect, setRedirect, goRedirect };
+}

--- a/src/hooks/common/useRouterGuard.tsx
+++ b/src/hooks/common/useRouterGuard.tsx
@@ -1,9 +1,10 @@
 import { useEffect, useState } from 'react';
 
-import { PUBLIC_ROUTES } from '~/constants/common';
+import { ADD_ROUTES, PUBLIC_ROUTES } from '~/constants/common';
 import { localStorageUserTokenKeys } from '~/constants/localStorage';
 
 import useInternalRouter from './useInternalRouter';
+import { useLoginRedirect } from './useLoginRedirect';
 
 interface UseRouterGuardProps {
   isLoaded: boolean;
@@ -12,6 +13,7 @@ interface UseRouterGuardProps {
 export default function useRouterGuard({ isLoaded }: UseRouterGuardProps) {
   const [isRouterGuardPassed, setIsRouterGuardPassed] = useState<boolean>(false);
   const router = useInternalRouter();
+  const { setRedirect } = useLoginRedirect();
 
   useEffect(() => {
     const authCheck = (url: string) => {
@@ -26,6 +28,9 @@ export default function useRouterGuard({ isLoaded }: UseRouterGuardProps) {
 
       const path = url.split('?')[0];
       if (!PUBLIC_ROUTES.includes(path)) {
+        if (ADD_ROUTES.includes(path)) {
+          setRedirect(path);
+        }
         router.push('/onboard');
       } else {
         // 로그인을 하지 않았으며, 퍼블릭 route에 방문시 패스 인증
@@ -39,7 +44,7 @@ export default function useRouterGuard({ isLoaded }: UseRouterGuardProps) {
     return () => {
       router.events.off('routeChangeStart', authCheck);
     };
-  }, [isLoaded, router]);
+  }, [isLoaded, router, setRedirect]);
 
   return { isRouterGuardPassed };
 }

--- a/src/pages/login/index.tsx
+++ b/src/pages/login/index.tsx
@@ -7,6 +7,7 @@ import useMemberLoginMutation from '~/hooks/api/member/useMemberLoginMutation';
 import useDidUpdate from '~/hooks/common/useDidUpdate';
 import useInput from '~/hooks/common/useInput';
 import useInternalRouter from '~/hooks/common/useInternalRouter';
+import { useLoginRedirect } from '~/hooks/common/useLoginRedirect';
 import { useUser } from '~/hooks/common/useUser';
 import { useToast } from '~/store/Toast';
 import { recordEvent } from '~/utils/analytics';
@@ -21,6 +22,7 @@ export default function Login() {
   const [passwordError, setPasswordError] = useState('');
   const { userLogin } = useUser();
   const { push } = useInternalRouter();
+  const { getRedirect, goRedirect } = useLoginRedirect();
 
   const {
     mutate: loginMutate,
@@ -60,6 +62,7 @@ export default function Login() {
   }, [password.debouncedValue]);
 
   useDidUpdate(() => {
+    //
     if (loginMutationData && loginMutationData.data) {
       userLogin({
         accessToken: loginMutationData.data.accessToken,
@@ -67,7 +70,12 @@ export default function Login() {
       });
       setIsPending(false);
       recordEvent({ action: 'Login', value: '로그인 화면에서 로그인' });
-      push('/');
+
+      if (getRedirect()) {
+        goRedirect();
+      } else {
+        push('/');
+      }
     }
   }, [loginMutationData]);
 


### PR DESCRIPTION
## ⛳️작업 내용
- 공유하기에서 접근할 경우, onBoard 페이지로 가지게되어 기존에 공유하려던 것을 한번 더해야되는 이슈 발생
- redirect를 queryString으로 남길 경우, onBoard -> login으로 갈때, 챙겨 주고 삭제 등등... 추가로직 발생함에 따라
- sessionStorage를 사용하는 hooks를 만들어 구현을 진행했습니다.
  - 해당 페이지로 이동한 뒤에 session의 redirect를 clear해줍니다.
  - 사용부에서 add 관련 path만 집어 넣을 수 있도록 구현했습니다.
<!-- 작업한 사항을 간략하게 적어주세요 -->

## 📸스크린샷
https://user-images.githubusercontent.com/59507527/175775835-2fc75a4e-e419-490c-b664-831b9e969983.mov


<!-- 스크린샷으로 작업한 사항을 보여주세요 -->

## ⚡️사용 방법
```ts
const { getRedirect, setRedirect, goRedirect } = useLoginRedirect();

/**
goRedirect의 경우, 해당 페이지로 이동한 뒤에 session의 redirect를 clear해줍니다.
*/
```
<!-- 공통 asset의 경우 사용법을 간략하게 적어봅시다 -->

## 📎레퍼런스

<!-- 참고한 레퍼런스가 있다면 기록해주세요 -->

<!--
리뷰어
혜성 : hyesungoh
도현 : ddarkr
대윤 : SenseCodeValue
은정 : positiveko
-->
