### PR TITLE
태그 추가 - 상단 바 완료버튼 추가

### DIFF
--- a/src/pages/add/tag.tsx
+++ b/src/pages/add/tag.tsx
@@ -1,17 +1,22 @@
+import { useCallback, useRef, useState } from 'react';
 import { motion } from 'framer-motion';
 
+import { GhostButton } from '~/components/common/Button';
 import LoadingHandler from '~/components/common/LoadingHandler';
 import NavigationBar from '~/components/common/NavigationBar';
 import { FixedSpinner } from '~/components/common/Spinner';
 import TagForm from '~/components/common/TagForm';
 import { defaultFadeInVariants } from '~/constants/motions';
 import useGetTagListWithInfinite from '~/hooks/api/tag/useGetTagListWithInfinite';
+import useTagMutation from '~/hooks/api/tag/useTagMutation';
+import useTagRefresh from '~/hooks/api/tag/useTagRefresh';
 import useIntersectionObserver from '~/hooks/common/useIntersectionObserver';
 import { useAppliedTags } from '~/store/AppliedTags';
+import { recordEvent } from '~/utils/analytics';
 
 export default function TagPage() {
-  const { tags: appliedTags, removeTag, addTag } = useAppliedTags();
   const { tags, isLoading, hasNextPage, fetchNextPage } = useGetTagListWithInfinite({});
+  const { tags: appliedTags, removeTag, addTag } = useAppliedTags();
 
   const { setTarget } = useIntersectionObserver({
     onIntersect: ([{ isIntersecting }]) => {
@@ -19,9 +24,54 @@ export default function TagPage() {
     },
   });
 
+  const { createTag } = useTagMutation();
+  const { refresh: tagListRefresh } = useTagRefresh();
+
+  const lastKeyword = useRef<string | null>(null);
+  const [keyword, setKeyword] = useState('');
+
+  const { tags: searchedTags, isLoading: isSeachLoading } = useGetTagListWithInfinite({
+    keyword,
+    isExactlySame: true,
+  });
+
+  const saveCreatedTag = useCallback(
+    (keyword: string) => {
+      createTag(keyword, {
+        onSuccess: data => {
+          recordEvent({ action: '태그 생성', value: keyword, label: '영감 편집 화면' });
+          addTag(data);
+          tagListRefresh();
+        },
+      });
+    },
+    [createTag, addTag, tagListRefresh]
+  );
+
+  const onSubmit = () => {
+    if (keyword === lastKeyword.current || isSeachLoading) return;
+    if (!keyword) return;
+
+    if (!searchedTags.length) {
+      saveCreatedTag(keyword);
+    } else {
+      addTag(searchedTags[0]);
+    }
+
+    lastKeyword.current = keyword;
+  };
+
   return (
     <article>
-      <NavigationBar title="태그 추가" backLinkScrollOption={false} />
+      <NavigationBar
+        title="태그 추가"
+        backLinkScrollOption={false}
+        rightElement={
+          <GhostButton size="large" onClick={onSubmit}>
+            추가
+          </GhostButton>
+        }
+      />
 
       <LoadingHandler isLoading={isLoading} loadingComponent={<FixedSpinner />}>
         <motion.div
@@ -35,6 +85,10 @@ export default function TagPage() {
             registeredTags={tags}
             onSave={addTag}
             onRemove={removeTag}
+            onSearch={keyoword => {
+              setKeyword(keyoword);
+            }}
+            onSubmit={onSubmit}
           />
           {hasNextPage && !isLoading && <div ref={setTarget}></div>}
         </motion.div>

--- a/src/pages/add/tag.tsx
+++ b/src/pages/add/tag.tsx
@@ -85,8 +85,8 @@ export default function TagPage() {
             registeredTags={tags}
             onSave={addTag}
             onRemove={removeTag}
-            onSearch={keyoword => {
-              setKeyword(keyoword);
+            onSearch={keyword => {
+              setKeyword(keyword);
             }}
             onSubmit={onSubmit}
           />

--- a/src/pages/edit/tag.tsx
+++ b/src/pages/edit/tag.tsx
@@ -1,7 +1,8 @@
-import { useEffect } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { css } from '@emotion/react';
 import { motion } from 'framer-motion';
 
+import { GhostButton } from '~/components/common/Button';
 import LoadingHandler from '~/components/common/LoadingHandler';
 import NavigationBar from '~/components/common/NavigationBar';
 import { FixedSpinner } from '~/components/common/Spinner';
@@ -10,6 +11,8 @@ import { defaultFadeInVariants } from '~/constants/motions';
 import { useInspirationById } from '~/hooks/api/inspiration/useInspirationById';
 import useInspirationMutation from '~/hooks/api/inspiration/useInspirationMutation';
 import useGetTagListWithInfinite from '~/hooks/api/tag/useGetTagListWithInfinite';
+import useTagMutation from '~/hooks/api/tag/useTagMutation';
+import useTagRefresh from '~/hooks/api/tag/useTagRefresh';
 import useInternalRouter from '~/hooks/common/useInternalRouter';
 import useIntersectionObserver from '~/hooks/common/useIntersectionObserver';
 import useQueryParam from '~/hooks/common/useRouterQuery';
@@ -59,9 +62,50 @@ export default function EditTag() {
     deleteInspirationTag({ id: Number(inspirationId), tagId });
   };
 
+  const { createTag } = useTagMutation();
+  const { refresh: tagListRefresh } = useTagRefresh();
+
+  const lastKeyword = useRef<string | null>(null);
+  const [keyword, setKeyword] = useState('');
+
+  const { tags: searchedTags, isLoading: isSeachLoading } = useGetTagListWithInfinite({
+    keyword,
+    isExactlySame: true,
+  });
+
+  const saveCreatedTag = (keyword: string) => {
+    createTag(keyword, {
+      onSuccess: data => {
+        recordEvent({ action: '태그 생성', value: keyword, label: '영감 편집 화면' });
+        saveTag(data);
+        tagListRefresh();
+      },
+    });
+  };
+
+  const onSubmit = () => {
+    if (keyword === lastKeyword.current || isSeachLoading) return;
+    if (!keyword) return;
+
+    if (!searchedTags.length) {
+      saveCreatedTag(keyword);
+    } else {
+      saveTag(searchedTags[0]);
+    }
+
+    lastKeyword.current = keyword;
+  };
+
   return (
     <article css={editTagCss}>
-      <NavigationBar title="영감 편집" />
+      <NavigationBar
+        title="영감 편집"
+        rightElement={
+          <GhostButton size="large" onClick={onSubmit}>
+            추가
+          </GhostButton>
+        }
+      />
       <LoadingHandler isLoading={isLoading} loadingComponent={<FixedSpinner />}>
         <motion.div
           variants={defaultFadeInVariants}
@@ -74,6 +118,10 @@ export default function EditTag() {
             registeredTags={tags}
             onSave={saveTag}
             onRemove={removeTag}
+            onSearch={keyoword => {
+              setKeyword(keyoword);
+            }}
+            onSubmit={onSubmit}
           />
           {hasNextPage && !isLoading && <div ref={setTarget}></div>}
         </motion.div>

--- a/src/pages/edit/tag.tsx
+++ b/src/pages/edit/tag.tsx
@@ -118,8 +118,8 @@ export default function EditTag() {
             registeredTags={tags}
             onSave={saveTag}
             onRemove={removeTag}
-            onSearch={keyoword => {
-              setKeyword(keyoword);
+            onSearch={keyword => {
+              setKeyword(keyword);
             }}
             onSubmit={onSubmit}
           />


### PR DESCRIPTION
## ⛳️작업 내용
- 기존의 TagForm에 비즈니스로직을 혼합하여 가지고 있던 부분을 제거하고 부모 컴포넌트로 이관했습니다.
- 이과정을 진행하면서, 부모(TagForm의 사용부)컴포넌트에서 `추가` 버튼을 통해 테그를 추가할 수 있도록 했습니다.

- 논의 되어야될 사항 
  - 이슈는 `완료` 텍스트를 사용하지만
  - 기존 `완료`를 했을 때 뒤로가지거나 하는 로직 추가가 애매한 점으로 남아있어
  - 먼저 `추가`로 바꾸고 입력된 tag를 추가하는 로직만을 하도록 구현했습니다.
<!-- 작업한 사항을 간략하게 적어주세요 -->


## 📸스크린샷
### 테그 추가
<img width="504" alt="스크린샷 2022-07-01 오전 12 37 29" src="https://user-images.githubusercontent.com/59507527/176719336-8fcca2ba-6df1-4000-a996-8092142f7908.png">
### 영감 편집 - 테그 편집
<img width="504" alt="스크린샷 2022-07-01 오전 12 37 43" src="https://user-images.githubusercontent.com/59507527/176719356-fed13bb2-7920-4c7a-aa52-ab94c56f16c6.png">

<!-- 스크린샷으로 작업한 사항을 보여주세요 -->

## ⚡️사용 방법
기존 필터 검색 부분 처럼 keyword가 입력될 때마다 keyword를 저장하고, onSubmit을 통해서 action을 실행할 수 있도록 개발했습니다.
```jsx
<TagForm
  applyedTags={inspiration?.tagResponses || []}
  registeredTags={tags}
  onSave={saveTag}
  onRemove={removeTag}
  onSearch={keyword => {
    setKeyword(keyword);
  }}
  onSubmit={onSubmit}
/>
```
<!-- 공통 asset의 경우 사용법을 간략하게 적어봅시다 -->

## 🚨 핵심 로직으로 테스트 꼼꼼히 진행된다음 머지 될 것

<!--
리뷰어
혜성 : hyesungoh
도현 : ddarkr
대윤 : SenseCodeValue
은정 : positiveko
-->
