### PR TITLE
이미지 저장 개발, AppMessage 관련 인터페이스 수정, IconButton 인터페이스 수정

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "react": "18.0.0",
     "react-dom": "18.0.0",
     "react-query": "^3.39.0",
+    "react-quick-pinch-zoom": "^4.4.1",
     "recoil": "^0.7.2"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,9 @@
   "dependencies": {
     "@emotion/react": "^11.9.0",
     "@sentry/nextjs": "^6.19.7",
+    "@types/file-saver": "^2.0.5",
     "axios": "^0.26.1",
+    "file-saver": "^2.0.5",
     "framer-motion": "^6.3.3",
     "js-cookie": "^3.0.1",
     "lodash": "^4.17.21",

--- a/package.json
+++ b/package.json
@@ -16,9 +16,7 @@
   "dependencies": {
     "@emotion/react": "^11.9.0",
     "@sentry/nextjs": "^6.19.7",
-    "@types/file-saver": "^2.0.5",
     "axios": "^0.26.1",
-    "file-saver": "^2.0.5",
     "framer-motion": "^6.3.3",
     "js-cookie": "^3.0.1",
     "lodash": "^4.17.21",

--- a/src/components/common/BottomSheetModal.tsx
+++ b/src/components/common/BottomSheetModal.tsx
@@ -6,6 +6,8 @@ import PortalWrapper from '~/components/common/PortalWrapper';
 import { defaultEasing, defaultFadeInVariants } from '~/constants/motions';
 import usePreventScroll from '~/hooks/common/usePreventScroll';
 
+import { dimBackdropCss } from './styles';
+
 export interface BottomSheetModalProps {
   isShowing: boolean;
   children: ReactNode;
@@ -43,20 +45,6 @@ export default function BottomSheetModal({ isShowing, children, onClose }: Botto
     </PortalWrapper>
   );
 }
-
-const dimBackdropCss = (theme: Theme) => css`
-  position: fixed;
-  z-index: 1000;
-  top: 0;
-  left: 0;
-
-  width: 100vw;
-  height: 100%;
-
-  background-color: ${theme.color.dim03};
-
-  overflow: hidden;
-`;
 
 const MARGIN_TOP = 54;
 const MIN_HIEGHT = 208;

--- a/src/components/common/Button/IconButton.tsx
+++ b/src/components/common/Button/IconButton.tsx
@@ -9,7 +9,21 @@ type ColorType = 'light' | 'dark';
 
 interface IconButtonProps extends Omit<ComponentProps<typeof Button>, 'children'> {
   iconName: keyof typeof icons;
+  /**
+   * @type 'light' | 'dark'
+   *
+   * @default 'dark'
+   *
+   * light일 시 gray05, dark일 시 background 색상이 적용됩니다.
+   *
+   * `light` props가 true일 시, light는 background, dark는 gray05로 적용됩니다.
+   */
   colorType?: ColorType;
+  /**
+   * 아이콘 버튼의 배경 색상을 `inherit`으로 설정합니다.
+   *
+   * `colorType` props의 적용 값을 반전시킵니다.
+   */
   light?: boolean;
   size?: number;
 }
@@ -34,11 +48,7 @@ const iconButtonCss = (theme: Theme, colorType: ColorType, light: boolean, size:
   height: ${size}px;
   padding: 2px;
 
-  color: ${light
-    ? theme.color.gray05
-    : colorType === 'dark'
-    ? theme.color.background
-    : theme.color.gray05};
+  color: ${light ? lightColorType(theme, colorType) : nonLightColorType(theme, colorType)};
 
   background-color: ${light
     ? 'inherit'
@@ -46,3 +56,18 @@ const iconButtonCss = (theme: Theme, colorType: ColorType, light: boolean, size:
     ? theme.color.gray05
     : theme.color.gray02};
 `;
+
+const nonLightColorType = (theme: Theme, colorType: ColorType) => {
+  if (colorType === 'dark') {
+    return theme.color.background;
+  }
+  return theme.color.gray05;
+};
+
+const lightColorType = (theme: Theme, colorType: ColorType) => {
+  if (colorType === 'dark') {
+    return theme.color.gray05;
+  }
+
+  return theme.color.background;
+};

--- a/src/components/common/Dialog.tsx
+++ b/src/components/common/Dialog.tsx
@@ -5,6 +5,8 @@ import { motion } from 'framer-motion';
 import PortalWrapper from '~/components/common/PortalWrapper';
 import { defaultFadeInUpVariants, defaultFadeInVariants } from '~/constants/motions';
 
+import { dimBackdropCss } from './styles';
+
 export interface DialogProps {
   isShowing?: boolean;
   actionButtons: ReactNode;
@@ -26,7 +28,7 @@ export default function Dialog({
     return (
       <PortalWrapper isShowing={true}>
         <motion.div
-          css={dimBackdropCss}
+          css={dimBackdropLayoutCss}
           variants={defaultFadeInVariants}
           initial="initial"
           animate="animate"
@@ -44,21 +46,12 @@ export default function Dialog({
   return <></>;
 }
 
-const dimBackdropCss = (theme: Theme) => css`
+const dimBackdropLayoutCss = (theme: Theme) => css`
   display: flex;
   align-items: center;
   justify-content: center;
 
-  position: fixed;
-  top: 0;
-  left: 0;
-  width: 100vw;
-  height: 100%;
-
-  background-color: ${theme.color.dim03};
-
-  z-index: 1000;
-  overflow: hidden;
+  ${dimBackdropCss(theme)}
 `;
 
 const dialogCss = (theme: Theme) => css`

--- a/src/components/common/IllustDialog.tsx
+++ b/src/components/common/IllustDialog.tsx
@@ -5,6 +5,8 @@ import { motion } from 'framer-motion';
 import PortalWrapper from '~/components/common/PortalWrapper';
 import { defaultFadeInUpVariants, defaultFadeInVariants } from '~/constants/motions';
 
+import { dimBackdropCss } from './styles';
+
 export interface IllustDialogProps {
   isShowing?: boolean;
   image: string;
@@ -28,7 +30,7 @@ export default function IllustDialog({
     return (
       <PortalWrapper isShowing={true}>
         <motion.div
-          css={dimBackdropCss}
+          css={dimBackdropLayoutCss}
           variants={defaultFadeInVariants}
           initial="initial"
           animate="animate"
@@ -49,21 +51,12 @@ export default function IllustDialog({
   return <></>;
 }
 
-const dimBackdropCss = (theme: Theme) => css`
+const dimBackdropLayoutCss = (theme: Theme) => css`
   display: flex;
   align-items: center;
   justify-content: center;
 
-  position: fixed;
-  top: 0;
-  left: 0;
-  width: 100vw;
-  height: 100%;
-
-  background-color: ${theme.color.dim03};
-
-  z-index: 1000;
-  overflow: hidden;
+  ${dimBackdropCss(theme)}
 `;
 
 const IllustContentContainerCss = css`

--- a/src/components/common/ImageContent.tsx
+++ b/src/components/common/ImageContent.tsx
@@ -151,15 +151,7 @@ function OpenedImageContent({ isOpen, toggleIsOpen, src, alt }: OpenedImageConte
             exit="exit"
           >
             <button onClick={toggleIsOpen}>닫기</button>
-            <a
-              href={src}
-              rel="nofollow"
-              download
-              onClick={e => {
-                e.preventDefault();
-                imageDownload({ href: src });
-              }}
-            >
+            <a href={src} download onClick={() => imageDownload({ href: src })}>
               저장2
             </a>
             {/* <button onClick={onClickDownloadButton}>저장</button> */}

--- a/src/components/common/ImageContent.tsx
+++ b/src/components/common/ImageContent.tsx
@@ -150,7 +150,14 @@ function OpenedImageContent({ isOpen, toggleIsOpen, src, alt }: OpenedImageConte
             exit="exit"
           >
             <button onClick={toggleIsOpen}>닫기</button>
-            <button onClick={onClickDownloadButton}>저장</button>
+            <button
+              onClick={e => {
+                onClickDownloadButton();
+                e.currentTarget.style.backgroundColor = 'red';
+              }}
+            >
+              저장
+            </button>
           </motion.div>
 
           <QuickPinchZoom onUpdate={onUpdate}>

--- a/src/components/common/ImageContent.tsx
+++ b/src/components/common/ImageContent.tsx
@@ -1,4 +1,4 @@
-import { MouseEvent, useCallback, useRef } from 'react';
+import { useCallback, useRef } from 'react';
 import { css, Theme, useTheme } from '@emotion/react';
 import { AnimatePresence, motion, Variants } from 'framer-motion';
 import QuickPinchZoom, { make3dTransformValue } from 'react-quick-pinch-zoom';
@@ -126,8 +126,7 @@ function OpenedImageContent({ isOpen, toggleIsOpen, src, alt }: OpenedImageConte
     }
   }, []);
 
-  const onClickDownloadButton = (e: MouseEvent<HTMLButtonElement>) => {
-    e.stopPropagation();
+  const onClickDownloadButton = () => {
     imageDownload({ href: src });
   };
 

--- a/src/components/common/ImageContent.tsx
+++ b/src/components/common/ImageContent.tsx
@@ -1,6 +1,11 @@
 import { css, Theme, useTheme } from '@emotion/react';
+import { motion } from 'framer-motion';
+
+import { defaultFadeInVariants } from '~/constants/motions';
+import useToggle from '~/hooks/common/useToggle';
 
 import { CancelIcon } from './icons';
+import { dimBackdropCss } from './styles';
 
 interface ImageContentProps {
   alt: string;
@@ -10,6 +15,8 @@ interface ImageContentProps {
   htmlFor?: string;
   onClickXBtn?: VoidFunction;
 }
+
+const IMG_LAYOUT_ID = 'content_image';
 
 export default function ImageContent({
   src,
@@ -21,25 +28,60 @@ export default function ImageContent({
 }: ImageContentProps) {
   const theme = useTheme();
 
+  const [isOpen, toggleIsOpen] = useToggle(false);
+
   return (
-    <div css={imgBoxCss({ width, height })}>
-      {src ? (
-        <>
-          {(onClickXBtn || htmlFor) && (
-            <label htmlFor={htmlFor} onClick={onClickXBtn} css={closeIconCss}>
-              <CancelIcon isUsingFill color={theme.color.gray05} />
-            </label>
-          )}
-          <img src={src} css={imgCss} alt={alt} />
-        </>
-      ) : (
-        <div onClick={onClickXBtn} css={emptyImageCss({ theme })}></div>
-      )}
-    </div>
+    <>
+      <div css={imgBoxCss({ width, height })}>
+        {src ? (
+          <>
+            {(onClickXBtn || htmlFor) && (
+              <label htmlFor={htmlFor} onClick={onClickXBtn} css={closeIconCss}>
+                <CancelIcon isUsingFill color={theme.color.gray05} />
+              </label>
+            )}
+
+            <motion.img
+              layoutId={IMG_LAYOUT_ID}
+              src={src}
+              css={imgCss}
+              alt={alt}
+              onClick={toggleIsOpen}
+            />
+
+            {isOpen && (
+              <motion.div
+                onClick={toggleIsOpen}
+                css={dimBackdropLayoutCss}
+                variants={defaultFadeInVariants}
+                initial="initial"
+                animate="animate"
+                exit="exit"
+              >
+                <motion.img
+                  layoutId={IMG_LAYOUT_ID}
+                  src={src}
+                  css={opendImgCss}
+                  alt={alt}
+                  onClick={toggleIsOpen}
+                />
+              </motion.div>
+            )}
+          </>
+        ) : (
+          <div onClick={onClickXBtn} css={emptyImageCss({ theme })}></div>
+        )}
+      </div>
+    </>
   );
 }
 
-const imgBoxCss = ({ width, height }: { width: string; height?: string }) => css`
+interface ImgBoxProps {
+  width: string;
+  height?: string;
+}
+
+const imgBoxCss = ({ width, height }: ImgBoxProps) => css`
   position: relative;
   width: ${width};
   height: ${height};
@@ -52,6 +94,22 @@ const imgCss = css`
   width: 100%;
   height: 100%;
   border-radius: 4px;
+  cursor: zoom-in;
+`;
+
+const dimBackdropLayoutCss = (theme: Theme) => css`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+
+  ${dimBackdropCss(theme)}
+`;
+
+const opendImgCss = css`
+  width: auto;
+  height: auto;
+
+  max-width: 100%;
 `;
 
 const closeIconCss = css`

--- a/src/components/common/ImageContent.tsx
+++ b/src/components/common/ImageContent.tsx
@@ -1,4 +1,4 @@
-import { MouseEvent, useCallback, useRef } from 'react';
+import { useCallback, useRef } from 'react';
 import { css, Theme, useTheme } from '@emotion/react';
 import { AnimatePresence, motion, Variants } from 'framer-motion';
 import QuickPinchZoom, { make3dTransformValue } from 'react-quick-pinch-zoom';
@@ -126,10 +126,10 @@ function OpenedImageContent({ isOpen, toggleIsOpen, src, alt }: OpenedImageConte
     }
   }, []);
 
-  const onClickDownloadButton = (e: MouseEvent<HTMLButtonElement>) => {
-    e.stopPropagation();
-    imageDownload({ href: src });
-  };
+  // const onClickDownloadButton = (e: MouseEvent<HTMLButtonElement>) => {
+  //   e.stopPropagation();
+  //   imageDownload({ href: src });
+  // };
 
   return (
     <AnimatePresence>
@@ -151,7 +151,18 @@ function OpenedImageContent({ isOpen, toggleIsOpen, src, alt }: OpenedImageConte
             exit="exit"
           >
             <button onClick={toggleIsOpen}>닫기</button>
-            <button onClick={onClickDownloadButton}>저장</button>
+            <a
+              href={src}
+              rel="nofollow"
+              download
+              onClick={e => {
+                e.preventDefault();
+                imageDownload({ href: src });
+              }}
+            >
+              저장2
+            </a>
+            {/* <button onClick={onClickDownloadButton}>저장</button> */}
           </motion.div>
 
           <QuickPinchZoom onUpdate={onUpdate}>

--- a/src/components/common/ImageContent.tsx
+++ b/src/components/common/ImageContent.tsx
@@ -117,10 +117,11 @@ function OpenedImageContent({ isOpen, toggleIsOpen, src, alt }: OpenedImageConte
       console.log(x, y, scale);
       const value = make3dTransformValue({ x, y, scale });
 
-      // TODO: overflow 속성 설정을 오픈소스 스펙에 추가 혹은 기여할 수 있을듯
+      // TODO: overflow 속성 설정을 오픈소스 스펙에 추가 혹은 기여할 수 있을듯 > 현재 대기중
       img.parentElement?.style.setProperty('overflow', 'visible');
 
       img.style.setProperty('transform', value);
+      // NOTE: framer-motion override 방지
       img.style.setProperty('transform-origin', '');
     }
   }, []);

--- a/src/components/common/ImageContent.tsx
+++ b/src/components/common/ImageContent.tsx
@@ -114,9 +114,14 @@ function OpenedImageContent({ isOpen, toggleIsOpen, src, alt }: OpenedImageConte
     const { current: img } = imgRef;
 
     if (img) {
+      console.log(x, y, scale);
       const value = make3dTransformValue({ x, y, scale });
 
+      // TODO: overflow 속성 설정을 오픈소스 스펙에 추가 혹은 기여할 수 있을듯
+      img.parentElement?.style.setProperty('overflow', 'visible');
+
       img.style.setProperty('transform', value);
+      img.style.setProperty('transform-origin', '');
     }
   }, []);
 
@@ -151,6 +156,7 @@ const dimBackdropLayoutCss = (theme: Theme) => css`
   display: flex;
   justify-content: center;
   align-items: center;
+  cursor: zoom-out;
 
   ${dimBackdropCss(theme)}
 `;
@@ -158,7 +164,7 @@ const dimBackdropLayoutCss = (theme: Theme) => css`
 const opendImgCss = css`
   width: auto;
   height: auto;
-
+  cursor: default;
   max-width: 100%;
   max-height: ${fullViewHeight()};
 `;

--- a/src/components/common/ImageContent.tsx
+++ b/src/components/common/ImageContent.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useRef } from 'react';
+import { MouseEvent, useCallback, useRef } from 'react';
 import { css, Theme, useTheme } from '@emotion/react';
 import { AnimatePresence, motion, Variants } from 'framer-motion';
 import QuickPinchZoom, { make3dTransformValue } from 'react-quick-pinch-zoom';
@@ -126,10 +126,10 @@ function OpenedImageContent({ isOpen, toggleIsOpen, src, alt }: OpenedImageConte
     }
   }, []);
 
-  // const onClickDownloadButton = (e: MouseEvent<HTMLButtonElement>) => {
-  //   e.stopPropagation();
-  //   imageDownload({ href: src });
-  // };
+  const onClickDownloadButton = (e: MouseEvent<HTMLButtonElement>) => {
+    e.stopPropagation();
+    imageDownload({ href: src });
+  };
 
   return (
     <AnimatePresence>
@@ -151,10 +151,7 @@ function OpenedImageContent({ isOpen, toggleIsOpen, src, alt }: OpenedImageConte
             exit="exit"
           >
             <button onClick={toggleIsOpen}>닫기</button>
-            <a href={src} download onClick={() => imageDownload({ href: src })}>
-              저장2
-            </a>
-            {/* <button onClick={onClickDownloadButton}>저장</button> */}
+            <button onClick={onClickDownloadButton}>저장</button>
           </motion.div>
 
           <QuickPinchZoom onUpdate={onUpdate}>

--- a/src/components/common/ImageContent.tsx
+++ b/src/components/common/ImageContent.tsx
@@ -154,14 +154,14 @@ function OpenedImageContent({ isOpen, toggleIsOpen, src, alt }: OpenedImageConte
               iconName="CloseIcon"
               onClick={toggleIsOpen}
               light
-              colorType="dark"
+              colorType="light"
               size={28}
             />
             <IconButton
               iconName="DownloadIcon"
               onClick={onClickDownloadButton}
               light
-              colorType="dark"
+              colorType="light"
               size={28}
             />
           </motion.div>
@@ -193,14 +193,13 @@ const dimBackdropLayoutCss = (theme: Theme) => css`
   cursor: zoom-out;
 `;
 
-const opendNavCss = (theme: Theme) => css`
+const opendNavCss = css`
   position: fixed;
   top: 0;
   left: 0;
   width: 100%;
   height: 44px;
   padding: 0 16px;
-  background-color: ${theme.color.gray06};
   cursor: default;
 
   display: flex;

--- a/src/components/common/ImageContent.tsx
+++ b/src/components/common/ImageContent.tsx
@@ -155,14 +155,14 @@ function OpenedImageContent({ isOpen, toggleIsOpen, src, alt }: OpenedImageConte
               onClick={toggleIsOpen}
               light
               colorType="dark"
-              size={44}
+              size={28}
             />
             <IconButton
               iconName="DownloadIcon"
               onClick={onClickDownloadButton}
               light
               colorType="dark"
-              size={44}
+              size={28}
             />
           </motion.div>
 
@@ -185,6 +185,7 @@ function OpenedImageContent({ isOpen, toggleIsOpen, src, alt }: OpenedImageConte
 const dimBackdropLayoutCss = (theme: Theme) => css`
   ${dimBackdropCss(theme)}
   width: 100%;
+  background-color: ${theme.color.gray06};
 
   display: flex;
   justify-content: center;
@@ -198,13 +199,14 @@ const opendNavCss = (theme: Theme) => css`
   left: 0;
   width: 100%;
   height: 44px;
-  padding: 0 2px;
-  background-color: ${theme.color.background};
+  padding: 0 16px;
+  background-color: ${theme.color.gray06};
   cursor: default;
 
   display: flex;
   justify-content: space-between;
   align-items: center;
+  z-index: 1100;
 `;
 
 const opendImgCss = css`
@@ -213,6 +215,7 @@ const opendImgCss = css`
   cursor: default;
   max-width: 100%;
   max-height: ${fullViewHeight()};
+  z-index: 1000;
 `;
 
 const imageOpendNavVariants: Variants = {

--- a/src/components/common/ImageContent.tsx
+++ b/src/components/common/ImageContent.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useRef } from 'react';
+import { MouseEvent, useCallback, useRef } from 'react';
 import { css, Theme, useTheme } from '@emotion/react';
 import { AnimatePresence, motion } from 'framer-motion';
 import QuickPinchZoom, { make3dTransformValue } from 'react-quick-pinch-zoom';
@@ -6,6 +6,7 @@ import QuickPinchZoom, { make3dTransformValue } from 'react-quick-pinch-zoom';
 import { defaultFadeInVariants } from '~/constants/motions';
 import useToggle from '~/hooks/common/useToggle';
 import { fullViewHeight } from '~/styles/utils';
+import { imageDownload } from '~/utils/common/imageDownload';
 
 import { CancelIcon } from './icons';
 import { dimBackdropCss } from './styles';
@@ -114,7 +115,6 @@ function OpenedImageContent({ isOpen, toggleIsOpen, src, alt }: OpenedImageConte
     const { current: img } = imgRef;
 
     if (img) {
-      console.log(x, y, scale);
       const value = make3dTransformValue({ x, y, scale });
 
       // TODO: overflow 속성 설정을 오픈소스 스펙에 추가 혹은 기여할 수 있을듯 > 현재 대기중
@@ -137,6 +137,14 @@ function OpenedImageContent({ isOpen, toggleIsOpen, src, alt }: OpenedImageConte
           animate="animate"
           exit="exit"
         >
+          <button
+            onClick={(e: MouseEvent<HTMLButtonElement>) => {
+              e.preventDefault();
+              imageDownload({ href: src });
+            }}
+          >
+            download
+          </button>
           <QuickPinchZoom onUpdate={onUpdate}>
             <motion.img
               ref={imgRef}

--- a/src/components/common/ImageContent.tsx
+++ b/src/components/common/ImageContent.tsx
@@ -8,6 +8,7 @@ import useToggle from '~/hooks/common/useToggle';
 import { fullViewHeight } from '~/styles/utils';
 import { imageDownload } from '~/utils/common/imageDownload';
 
+import { IconButton } from './Button';
 import { CancelIcon } from './icons';
 import { dimBackdropCss } from './styles';
 
@@ -149,15 +150,20 @@ function OpenedImageContent({ isOpen, toggleIsOpen, src, alt }: OpenedImageConte
             animate="animate"
             exit="exit"
           >
-            <button onClick={toggleIsOpen}>닫기</button>
-            <button
-              onClick={e => {
-                onClickDownloadButton();
-                e.currentTarget.style.backgroundColor = 'red';
-              }}
-            >
-              저장
-            </button>
+            <IconButton
+              iconName="CloseIcon"
+              onClick={toggleIsOpen}
+              light
+              colorType="dark"
+              size={44}
+            />
+            <IconButton
+              iconName="DownloadIcon"
+              onClick={onClickDownloadButton}
+              light
+              colorType="dark"
+              size={44}
+            />
           </motion.div>
 
           <QuickPinchZoom onUpdate={onUpdate}>
@@ -192,7 +198,7 @@ const opendNavCss = (theme: Theme) => css`
   left: 0;
   width: 100%;
   height: 44px;
-  padding: 0 16px;
+  padding: 0 2px;
   background-color: ${theme.color.background};
   cursor: default;
 

--- a/src/components/common/ImageContent.tsx
+++ b/src/components/common/ImageContent.tsx
@@ -177,12 +177,13 @@ function OpenedImageContent({ isOpen, toggleIsOpen, src, alt }: OpenedImageConte
 }
 
 const dimBackdropLayoutCss = (theme: Theme) => css`
+  ${dimBackdropCss(theme)}
+  width: 100%;
+
   display: flex;
   justify-content: center;
   align-items: center;
   cursor: zoom-out;
-
-  ${dimBackdropCss(theme)}
 `;
 
 const opendNavCss = (theme: Theme) => css`

--- a/src/components/common/icons/DownloadIcon.tsx
+++ b/src/components/common/icons/DownloadIcon.tsx
@@ -1,0 +1,10 @@
+import Svg, { SvgProps } from '~/components/common/Svg';
+
+export function DownloadIcon({ ...props }: SvgProps) {
+  return (
+    <Svg viewBox={24} {...props}>
+      <path d="M0 0h24v24H0z" fill="none" />
+      <path d="M19 9h-4V3H9v6H5l7 7 7-7zM5 18v2h14v-2H5z" />
+    </Svg>
+  );
+}

--- a/src/components/common/icons/index.ts
+++ b/src/components/common/icons/index.ts
@@ -4,6 +4,7 @@ export { CheckIcon } from './CheckIcon';
 export { ChevronIcon } from './ChevronIcon';
 export { CloseIcon } from './CloseIcon';
 export { DeleteIcon } from './DeleteIcon';
+export { DownloadIcon } from './DownloadIcon';
 export { EditIcon } from './EditIcon';
 export { FilterIcon } from './FilterIcon';
 export { HomeIcon } from './HomeIcon';

--- a/src/components/common/styles.ts
+++ b/src/components/common/styles.ts
@@ -10,3 +10,17 @@ export const labelCss = (theme: Theme) => css`
   font-weight: 500;
   line-height: 150%;
 `;
+
+export const dimBackdropCss = (theme: Theme) => css`
+  position: fixed;
+  z-index: 1000;
+  top: 0;
+  left: 0;
+
+  width: 100vw;
+  height: 100%;
+
+  background-color: ${theme.color.dim03};
+
+  overflow: hidden;
+`;

--- a/src/components/home/AppendButton.tsx
+++ b/src/components/home/AppendButton.tsx
@@ -6,6 +6,7 @@ import PortalWrapper from '~/components/common/PortalWrapper';
 import { defaultEasing, defaultFadeInVariants } from '~/constants/motions';
 import useToggle from '~/hooks/common/useToggle';
 
+import { dimBackdropCss } from '../common/styles';
 import AppendTooltip from './AppendTooltip';
 
 export default function AppendButton() {
@@ -26,7 +27,7 @@ export default function AppendButton() {
 
       <PortalWrapper isShowing={isShowing}>
         <motion.div
-          css={backdropCss}
+          css={dimBackdropCss}
           onClick={toggleIsShowing}
           variants={defaultFadeInVariants}
           initial="initial"
@@ -54,16 +55,6 @@ const buttonCss = (theme: Theme) => css`
   border-radius: 50%;
   color: ${theme.color.gray06};
   z-index: 999;
-`;
-
-const backdropCss = (theme: Theme) => css`
-  position: fixed;
-  top: 0;
-  left: 0;
-  width: 100vw;
-  height: 100%;
-  background-color: ${theme.color.dim03};
-  z-index: 998;
 `;
 
 const buttonRotateVariants: Variants = {

--- a/src/components/home/ThumbnailContent.tsx
+++ b/src/components/home/ThumbnailContent.tsx
@@ -25,6 +25,34 @@ const imageCss = css`
   object-fit: cover;
 `;
 
+const textCss = css`
+  font-size: 12px;
+  padding: 6px;
+  line-height: 150%;
+`;
+
+function LinkContent({ openGraph }: Pick<ContentThumbnailProps, 'openGraph'>) {
+  const [og, setOg] = useState<OpenGraphResponse>();
+  const { src, onImageError } = useOpenGraphImage({ url: og?.url, image: og?.image });
+
+  useDidMount(() => {
+    setOg(openGraph);
+  });
+
+  return (
+    <div css={linkWrapperCss}>
+      <div css={linkImgWrapperCss}>
+        {src && <img alt={`${og?.url} thumbnail`} src={src} onError={onImageError} />}
+      </div>
+
+      <div css={linkTextWrapperCss}>
+        <p>{og?.title}</p>
+        <p>{og?.url}</p>
+      </div>
+    </div>
+  );
+}
+
 const linkWrapperCss = css`
   width: 100%;
   height: 100%;
@@ -57,31 +85,3 @@ const linkTextWrapperCss = (theme: Theme) => css`
     ${textEllipsisCss(1)}
   }
 `;
-
-const textCss = css`
-  font-size: 12px;
-  padding: 6px;
-  line-height: 150%;
-`;
-
-function LinkContent({ openGraph }: Pick<ContentThumbnailProps, 'openGraph'>) {
-  const [og, setOg] = useState<OpenGraphResponse>();
-  const { src, onImageError } = useOpenGraphImage({ url: og?.url, image: og?.image });
-
-  useDidMount(() => {
-    setOg(openGraph);
-  });
-
-  return (
-    <div css={linkWrapperCss}>
-      <div css={linkImgWrapperCss}>
-        {src && <img alt={`${og?.url} thumbnail`} src={src} onError={onImageError} />}
-      </div>
-
-      <div css={linkTextWrapperCss}>
-        <p>{og?.title}</p>
-        <p>{og?.url}</p>
-      </div>
-    </div>
-  );
-}

--- a/src/components/inspiration/ImageView.tsx
+++ b/src/components/inspiration/ImageView.tsx
@@ -35,7 +35,7 @@ export default function ImageView({ inspiration }: { inspiration: InspirationInt
   return (
     <>
       <article css={addImageCss}>
-        <form css={formCss}>
+        <div css={formCss}>
           <section css={addImageTopCss}>
             <div css={contentWrapperCss}>
               <ImageContent src={content ?? null} alt="uploadedImg" />
@@ -56,7 +56,7 @@ export default function ImageView({ inspiration }: { inspiration: InspirationInt
               />
             </div>
           </section>
-        </form>
+        </div>
       </article>
       <AddTagFormRouteAsModal />
     </>

--- a/src/components/inspiration/ImageView.tsx
+++ b/src/components/inspiration/ImageView.tsx
@@ -38,7 +38,7 @@ export default function ImageView({ inspiration }: { inspiration: InspirationInt
         <form css={formCss}>
           <section css={addImageTopCss}>
             <div css={contentWrapperCss}>
-              {<ImageContent src={content ?? null} alt="uploadedImg" />}
+              <ImageContent src={content ?? null} alt="uploadedImg" />
             </div>
             <div css={contentWrapperCss}>
               <TagContent tags={tagResponses} inspirationId={inspiration.id} />

--- a/src/constants/motions.ts
+++ b/src/constants/motions.ts
@@ -54,18 +54,15 @@ export const defaultFadeInScaleVariants: Variants = {
     opacity: 0,
     scale: 0.85,
     transition: { duration: 0.8, ease: defaultEasing },
-    willChange: 'opacity, transform',
   },
   animate: {
     opacity: 1,
     scale: 1,
     transition: { duration: 0.8, ease: defaultEasing },
-    willChange: 'opacity, transform',
   },
   exit: {
     opacity: 0,
     scale: 0.85,
     transition: { duration: 0.8, ease: defaultEasing },
-    willChange: 'opacity, transform',
   },
 };

--- a/src/hooks/bridge/useAppMessage/AppMessageListener.tsx
+++ b/src/hooks/bridge/useAppMessage/AppMessageListener.tsx
@@ -2,8 +2,12 @@ import { PropsWithChildren, useEffect } from 'react';
 
 import { AppMessageArgs, useAppMessage } from './useAppMessage';
 
-export function AppMessageListener({ children, handler }: PropsWithChildren<AppMessageArgs>) {
-  const { startListening, stopListening } = useAppMessage({ handler });
+export function AppMessageListener({
+  children,
+  handler,
+  targetType,
+}: PropsWithChildren<AppMessageArgs>) {
+  const { startListening, stopListening } = useAppMessage({ handler, targetType });
 
   useEffect(() => {
     if (startListening) {

--- a/src/hooks/common/useUserAgent/useUserAgent.ts
+++ b/src/hooks/common/useUserAgent/useUserAgent.ts
@@ -6,7 +6,7 @@ interface IUseUserAgent {
   isDesktop: () => boolean;
 }
 
-const getMobileDetect = (userAgent: string): IUseUserAgent => {
+export const getMobileDetect = (userAgent: string): IUseUserAgent => {
   const isAndroid = (): boolean => Boolean(userAgent.match(/Android/i));
   const isIos = (): boolean => Boolean(userAgent.match(/iPhone|iPad|iPod/i));
   const isMobile = (): boolean => Boolean(isAndroid() || isIos());

--- a/src/pages/add/share.tsx
+++ b/src/pages/add/share.tsx
@@ -1,11 +1,12 @@
-import { useCallback } from 'react';
-
 import { AppMessageListener } from '~/hooks/bridge/useAppMessage';
 
 export default function AddShare() {
-  const handleMessage = useCallback((action: string, data?: any) => {
-    console.log('action: ', action, ' data: ', data);
-  }, []);
-
-  return <AppMessageListener handler={handleMessage}></AppMessageListener>;
+  return (
+    <AppMessageListener
+      targetType="YgtangAppShareData"
+      handler={({ type, data }) => {
+        console.log('type: ', type, ' data: ', data);
+      }}
+    ></AppMessageListener>
+  );
 }

--- a/src/utils/common/imageDownload.ts
+++ b/src/utils/common/imageDownload.ts
@@ -3,7 +3,7 @@ interface Props {
 }
 
 export async function imageDownload({ href }: Props) {
-  const imageResponse = await fetch(href, { mode: 'no-cors' });
+  const imageResponse = await fetch(href, { mode: 'cors', cache: 'no-cache' });
   const imageBlob = await imageResponse.blob();
   const imageObjectUrl = window.URL.createObjectURL(imageBlob);
 

--- a/src/utils/common/imageDownload.ts
+++ b/src/utils/common/imageDownload.ts
@@ -3,7 +3,7 @@ interface Props {
 }
 
 export async function imageDownload({ href }: Props) {
-  const imageResponse = await fetch(href);
+  const imageResponse = await fetch(href, { mode: 'no-cors' });
   const imageBlob = await imageResponse.blob();
   const imageObjectUrl = window.URL.createObjectURL(imageBlob);
 

--- a/src/utils/common/imageDownload.ts
+++ b/src/utils/common/imageDownload.ts
@@ -1,3 +1,5 @@
+import { saveAs } from 'file-saver';
+
 interface Props {
   href: string;
 }
@@ -7,17 +9,25 @@ export async function imageDownload({ href }: Props) {
   const imageBlob = await imageResponse.blob();
   const imageObjectUrl = window.URL.createObjectURL(imageBlob);
 
-  const element = document.createElement('a');
-  element.href = imageObjectUrl;
-
   const imageName = new Date().getTime();
   const imageExtension = href.split('.').at(-1);
 
-  element.download = `${imageName}.${imageExtension}`;
+  saveAs(imageObjectUrl, `${imageName}.${imageExtension}`);
 
-  document.body.appendChild(element);
-  element.dispatchEvent(new MouseEvent('click'));
-  document.body.removeChild(element);
+  // const imageResponse = await fetch(href);
+  // const imageBlob = await imageResponse.blob();
+  // const imageObjectUrl = window.URL.createObjectURL(imageBlob);
 
-  window.URL.revokeObjectURL(imageObjectUrl);
+  // const element = document.createElement('a');
+  // element.href = imageObjectUrl;
+
+  // const imageName = new Date().getTime();
+  // const imageExtension = href.split('.').at(-1);
+  // element.download = `${imageName}.${imageExtension}`;
+
+  // document.body.appendChild(element);
+  // element.dispatchEvent(new MouseEvent('click'));
+  // document.body.removeChild(element);
+
+  // window.URL.revokeObjectURL(imageObjectUrl);
 }

--- a/src/utils/common/imageDownload.ts
+++ b/src/utils/common/imageDownload.ts
@@ -1,5 +1,3 @@
-import { saveAs } from 'file-saver';
-
 interface Props {
   href: string;
 }
@@ -9,25 +7,13 @@ export async function imageDownload({ href }: Props) {
   const imageBlob = await imageResponse.blob();
   const imageObjectUrl = window.URL.createObjectURL(imageBlob);
 
+  const element = document.createElement('a');
+  element.href = imageObjectUrl;
+
   const imageName = new Date().getTime();
   const imageExtension = href.split('.').at(-1);
+  element.download = `${imageName}.${imageExtension}`;
+  element.click();
 
-  saveAs(imageObjectUrl, `${imageName}.${imageExtension}`);
-
-  // const imageResponse = await fetch(href);
-  // const imageBlob = await imageResponse.blob();
-  // const imageObjectUrl = window.URL.createObjectURL(imageBlob);
-
-  // const element = document.createElement('a');
-  // element.href = imageObjectUrl;
-
-  // const imageName = new Date().getTime();
-  // const imageExtension = href.split('.').at(-1);
-  // element.download = `${imageName}.${imageExtension}`;
-
-  // document.body.appendChild(element);
-  // element.dispatchEvent(new MouseEvent('click'));
-  // document.body.removeChild(element);
-
-  // window.URL.revokeObjectURL(imageObjectUrl);
+  window.URL.revokeObjectURL(imageObjectUrl);
 }

--- a/src/utils/common/imageDownload.ts
+++ b/src/utils/common/imageDownload.ts
@@ -1,0 +1,19 @@
+interface Props {
+  href: string;
+}
+
+export async function imageDownload({ href }: Props) {
+  const imageResponse = await fetch(href);
+  const imageBlob = await imageResponse.blob();
+  const imageObjectUrl = window.URL.createObjectURL(imageBlob);
+
+  const element = document.createElement('a');
+  element.href = imageObjectUrl;
+
+  const imageName = new Date().getTime();
+  const imageExtension = href.split('.').at(-1); // 업로드시와 동일한 확장자
+  element.download = `${imageName}.${imageExtension}`;
+  element.click();
+
+  window.URL.revokeObjectURL(imageObjectUrl);
+}

--- a/src/utils/common/imageDownload.ts
+++ b/src/utils/common/imageDownload.ts
@@ -7,19 +7,16 @@ export async function imageDownload({ href }: Props) {
   const imageBlob = await imageResponse.blob();
   const imageObjectUrl = window.URL.createObjectURL(imageBlob);
 
-  console.log(imageObjectUrl);
-
   const element = document.createElement('a');
   element.href = imageObjectUrl;
 
   const imageName = new Date().getTime();
   const imageExtension = href.split('.').at(-1);
+
   element.download = `${imageName}.${imageExtension}`;
 
   document.body.appendChild(element);
-
   element.dispatchEvent(new MouseEvent('click'));
-
   document.body.removeChild(element);
 
   window.URL.revokeObjectURL(imageObjectUrl);

--- a/src/utils/common/imageDownload.ts
+++ b/src/utils/common/imageDownload.ts
@@ -4,7 +4,7 @@ interface Props {
   href: string;
 }
 
-export async function imageDownload({ href }: Props) {
+export function imageDownload({ href }: Props) {
   const { isMobile } = getMobileDetect(navigator.userAgent);
 
   if (isMobile()) {
@@ -18,8 +18,6 @@ export async function imageDownload({ href }: Props) {
 function downloadImageWhenMobile({ href }: Props) {
   const element = document.createElement('a');
   element.href = href;
-
-  element.download = getImageNameAndExtension({ href });
 
   element.click();
 }

--- a/src/utils/common/imageDownload.ts
+++ b/src/utils/common/imageDownload.ts
@@ -3,7 +3,7 @@ interface Props {
 }
 
 export async function imageDownload({ href }: Props) {
-  const imageResponse = await fetch(href, { mode: 'cors', cache: 'no-cache' });
+  const imageResponse = await fetch(href, { mode: 'cors' });
   const imageBlob = await imageResponse.blob();
   const imageObjectUrl = window.URL.createObjectURL(imageBlob);
 

--- a/src/utils/common/imageDownload.ts
+++ b/src/utils/common/imageDownload.ts
@@ -3,7 +3,7 @@ interface Props {
 }
 
 export async function imageDownload({ href }: Props) {
-  const imageResponse = await fetch(href, { mode: 'cors' });
+  const imageResponse = await fetch(href, { mode: 'cors', cache: 'no-cache' });
   const imageBlob = await imageResponse.blob();
   const imageObjectUrl = window.URL.createObjectURL(imageBlob);
 

--- a/src/utils/common/imageDownload.ts
+++ b/src/utils/common/imageDownload.ts
@@ -7,13 +7,20 @@ export async function imageDownload({ href }: Props) {
   const imageBlob = await imageResponse.blob();
   const imageObjectUrl = window.URL.createObjectURL(imageBlob);
 
+  console.log(imageObjectUrl);
+
   const element = document.createElement('a');
   element.href = imageObjectUrl;
 
   const imageName = new Date().getTime();
-  const imageExtension = href.split('.').at(-1); // 업로드시와 동일한 확장자
+  const imageExtension = href.split('.').at(-1);
   element.download = `${imageName}.${imageExtension}`;
-  element.click();
+
+  document.body.appendChild(element);
+
+  element.dispatchEvent(new MouseEvent('click'));
+
+  document.body.removeChild(element);
 
   window.URL.revokeObjectURL(imageObjectUrl);
 }

--- a/src/utils/common/imageDownload.ts
+++ b/src/utils/common/imageDownload.ts
@@ -1,19 +1,46 @@
+import { getMobileDetect } from '~/hooks/common/useUserAgent/useUserAgent';
+
 interface Props {
   href: string;
 }
 
 export async function imageDownload({ href }: Props) {
+  const { isMobile } = getMobileDetect(navigator.userAgent);
+
+  if (isMobile()) {
+    downloadImageWhenMobile({ href });
+    return;
+  }
+
+  downloadImageWhenNotMobile({ href });
+}
+
+function downloadImageWhenMobile({ href }: Props) {
+  const element = document.createElement('a');
+  element.href = href;
+
+  element.download = getImageNameAndExtension({ href });
+
+  element.click();
+}
+
+async function downloadImageWhenNotMobile({ href }: Props) {
+  const element = document.createElement('a');
   const imageResponse = await fetch(href, { mode: 'cors', cache: 'no-cache' });
   const imageBlob = await imageResponse.blob();
   const imageObjectUrl = window.URL.createObjectURL(imageBlob);
-
-  const element = document.createElement('a');
   element.href = imageObjectUrl;
 
-  const imageName = new Date().getTime();
-  const imageExtension = href.split('.').at(-1);
-  element.download = `${imageName}.${imageExtension}`;
+  element.download = getImageNameAndExtension({ href });
+
   element.click();
 
   window.URL.revokeObjectURL(imageObjectUrl);
+}
+
+function getImageNameAndExtension({ href }: Props) {
+  const imageName = new Date().getTime();
+  const imageExtension = href.split('.').at(-1);
+
+  return `${imageName}.${imageExtension}`;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1133,11 +1133,6 @@
   dependencies:
     "@babel/types" "^7.3.0"
 
-"@types/file-saver@^2.0.5":
-  version "2.0.5"
-  resolved "https://registry.yarnpkg.com/@types/file-saver/-/file-saver-2.0.5.tgz#9ee342a5d1314bb0928375424a2f162f97c310c7"
-  integrity sha512-zv9kNf3keYegP5oThGLaPk8E081DFDuwfqjtiTzm6PoxChdJ1raSuADf2YGCVIyrSynLrgc8JWv296s7Q7pQSQ==
-
 "@types/graceful-fs@^4.1.2", "@types/graceful-fs@^4.1.3":
   version "4.1.5"
   resolved "https://registry.npmjs.org/@types/graceful-fs/-/graceful-fs-4.1.5.tgz"
@@ -3396,11 +3391,6 @@ file-entry-cache@^6.0.1:
   integrity sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==
   dependencies:
     flat-cache "^3.0.4"
-
-file-saver@^2.0.5:
-  version "2.0.5"
-  resolved "https://registry.yarnpkg.com/file-saver/-/file-saver-2.0.5.tgz#d61cfe2ce059f414d899e9dd6d4107ee25670c38"
-  integrity sha512-P9bmyZ3h/PRG+Nzga+rbdI4OEpNDzAVyy74uVO9ATgzLK6VtAsYybF/+TOCvrc0MO793d6+42lLyZTw7/ArVzA==
 
 fill-range@^4.0.0:
   version "4.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5767,6 +5767,11 @@ react-query@^3.39.0:
     broadcast-channel "^3.4.1"
     match-sorter "^6.0.2"
 
+react-quick-pinch-zoom@^4.4.1:
+  version "4.4.1"
+  resolved "https://registry.yarnpkg.com/react-quick-pinch-zoom/-/react-quick-pinch-zoom-4.4.1.tgz#2c8fbb2c6cb82731752cc2864e150e2582c2c7b3"
+  integrity sha512-nEPZi1DlMBmB8oLm7TGzHSGD33krwJKd+ihCBCoCLnXgQSZlJMsKxqWv2i32PYw4yenuTMBEMA0XLM/tXusA1Q==
+
 react@18.0.0:
   version "18.0.0"
   resolved "https://registry.npmjs.org/react/-/react-18.0.0.tgz"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1133,6 +1133,11 @@
   dependencies:
     "@babel/types" "^7.3.0"
 
+"@types/file-saver@^2.0.5":
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/@types/file-saver/-/file-saver-2.0.5.tgz#9ee342a5d1314bb0928375424a2f162f97c310c7"
+  integrity sha512-zv9kNf3keYegP5oThGLaPk8E081DFDuwfqjtiTzm6PoxChdJ1raSuADf2YGCVIyrSynLrgc8JWv296s7Q7pQSQ==
+
 "@types/graceful-fs@^4.1.2", "@types/graceful-fs@^4.1.3":
   version "4.1.5"
   resolved "https://registry.npmjs.org/@types/graceful-fs/-/graceful-fs-4.1.5.tgz"
@@ -3391,6 +3396,11 @@ file-entry-cache@^6.0.1:
   integrity sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==
   dependencies:
     flat-cache "^3.0.4"
+
+file-saver@^2.0.5:
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/file-saver/-/file-saver-2.0.5.tgz#d61cfe2ce059f414d899e9dd6d4107ee25670c38"
+  integrity sha512-P9bmyZ3h/PRG+Nzga+rbdI4OEpNDzAVyy74uVO9ATgzLK6VtAsYybF/+TOCvrc0MO793d6+42lLyZTw7/ArVzA==
 
 fill-range@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
⚠️ https://github.com/depromeet/ygtang-app/pull/119 가 배포된 후 머지되어야 합니다

## ⛳️작업 내용

### - `IconButton` 인터페이스 수정

  기존 `light` 모드로 적용할 시 아이콘의 색상이 `gray05`로 고정되었는데,

  `light` 모드일 시 `colorType='light'` 이면 `background`로, `colorType='dark'`이면 `gray05`로 적용되는 것이,
더 직관적일 것 같아 수정했어요

<br />

### - `dimBackdropCss` 모듈화

  사용되는 곳마다 선언되고 있던 style을 모듈화했어요

<br />

### - [이미지 전체보기 구현](https://github.com/depromeet/ygtang-client/pull/474/files#diff-2e8385f52be19bd3df2c34a5b348cc43665c8276e090cd4e56adaca43abd1383)

줌과 이동을 위해 도현님께서 말씀해주신 `react-quick-pinch-zoom` 라이브러리를 사용했어요

https://github.com/depromeet/ygtang-client/blob/546d828bfece59b32c75ad1159212a60b0f0bef7/src/components/common/ImageContent.tsx#L121-L122

해당 부분의 overflow 속성이 고정되어 있어, 
[추가한 후 PR](https://github.com/retyui/react-quick-pinch-zoom/pull/56) 해봤는데 className을 이용해 확장 가능하다는 답변을 받았는데 이상하게도 적용되지 않더라구요

추가적인 확인 후 리팩토링 가능할 거 같아요

<br />

### - [이미지 다운로드 구현](https://github.com/depromeet/ygtang-client/pull/474/files#diff-f5246e5c8c63e5ddbb285c40ccb8f2fbb07028ee3b2ec0a30db6f71fa40da629)

모바일 환경일 시 `href`에 `s3 url`을 넣어 RN에서 확인 후 저장할 수 있도록 적용했고,

이 외의 환경일 시 blob화하여 저장할 수 있도록 적용했어요

<br />

### - `useAppMessage`, `AppMessageListener` 인터페이스 추가 및 변경

- 기존 App 에서는 `type`으로 정의되어있던 RawData가 `action`이라는 이름으로 되어있는 것을 `type`으로 변경했어요
 https://github.com/depromeet/ygtang-client/blob/a9c6a4589822f39482e59ddd56f633360b0c5cc5/src/hooks/bridge/useAppMessage/useAppMessage.ts#L3-L16

- type을 App에서 사용하는 `WEBVIEW_MESSAGE_TYPE`의 값으로 정의했어요

- `targetType`이라는 추가 인터페이스를 넣었어요
  - 타겟팅하는 타입을 사용해, `handler`가 아닌 `useAppMessage`에서 타입에 대한 조건문을 위임했어요
    https://github.com/depromeet/ygtang-client/blob/a9c6a4589822f39482e59ddd56f633360b0c5cc5/src/hooks/bridge/useAppMessage/useAppMessage.ts#L27-L30
  
<br />

### - 이미지 다운로드 완료 혹은 실패 시 토스트 메세지 띄움

https://github.com/depromeet/ygtang-client/blob/a9c6a4589822f39482e59ddd56f633360b0c5cc5/src/components/common/ImageContent.tsx#L139-L145

> `targetType`의 값의 type이 `WEBVIEW_MESSAGE_TYPE[key]` 임으로 정해진 텍스트만 사용이 가능해요

<!-- 작업한 사항을 간략하게 적어주세요 -->

## 📸스크린샷


https://user-images.githubusercontent.com/26461307/180942816-d12bfd15-dc5f-4aee-a23a-85c33273bc8b.mov



## ⚡️사용 방법

### - `dimBackdropCss`

- 그대로 사용하기
  
```tsx
import { dimBackdropCss } from './styles';
<div css={dimBackdropCss} />
```

- 확장해서 사용하기

```tsx
<div css={dimBackdropLayoutCss} />

const dimBackdropLayoutCss = (theme: Theme) => css`
  ${dimBackdropCss(theme)}
  width: 100%;
  background-color: ${theme.color.gray06};
  display: flex;
  justify-content: center;
  align-items: center;
  cursor: zoom-out;
`;
```

### - `useAppMessage`

```tsx
useAppMessage({
  targetType: 'SendToastMessage',
  handler: ({ type, data, otherPropsFromApp }) => {
    console.log(type, data, otherPropsFromApp);
  },
});
```

![스크린샷 2022-07-26 오후 3 56 24](https://user-images.githubusercontent.com/26461307/180943066-eec645e1-902d-4f37-83d6-d0180914dba3.png)

<br />

### - `AppMessageListener`

- 인라인 handler

```tsx
export function Foo() {
  return (
    <AppMessageListener
      targetType="SendToastMessage"
      handler={({ type, data, otherProps }) => {
        console.log(type, data, otherProps);
      }}
    >
      <div></div>
    </AppMessageListener>
  );
}
```

- 분리된 handler

```tsx
export function Foo() {
  function fooHandler({ type, data, otherProps }: AppMessageData) {
    console.log(type, data, otherProps);
  }

  return (
    <AppMessageListener targetType="SendToastMessage" handler={fooHandler}>
      <div></div>
    </AppMessageListener>
  );
}
```

## 📎레퍼런스

<!-- 참고한 레퍼런스가 있다면 기록해주세요 -->

<!--
리뷰어
혜성 : hyesungoh
도현 : ddarkr
대윤 : SenseCodeValue
은정 : positiveko
-->
