### PR TITLE
회원가입 CTA 버튼 위치 수정

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -87,15 +87,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
-      - name: Caching dependencies
-        uses: actions/cache@v1
-        with:
-          path: node_modules
-          key: ${{ runner.OS }}-build-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.OS }}-build-
-            ${{ runner.OS }}-
-
       - name: Install dependencies
         run: yarn
 

--- a/src/pages/signup/email-verified.tsx
+++ b/src/pages/signup/email-verified.tsx
@@ -13,6 +13,7 @@ import useRouterQuery from '~/hooks/common/useRouterQuery';
 import useToggle from '~/hooks/common/useToggle';
 import useSignupUser from '~/store/Signup/useSignupUser';
 import { useToast } from '~/store/Toast';
+import { fullViewHeight } from '~/styles/utils';
 import { validator } from '~/utils/validator';
 
 export default function SignUpEmailVerified() {
@@ -162,10 +163,10 @@ export default function SignUpEmailVerified() {
 }
 
 const containerCss = css`
+  height: ${fullViewHeight()};
   display: flex;
   flex-direction: column;
-
-  height: 100%;
+  padding-bottom: 32px;
 `;
 
 const introTextWrapper = (theme: Theme) => css`

--- a/src/pages/signup/information.tsx
+++ b/src/pages/signup/information.tsx
@@ -128,6 +128,7 @@ const mainCss = css`
   height: ${fullViewHeight()};
   display: flex;
   flex-direction: column;
+  padding-bottom: 32px;
 `;
 
 const sectionCss = css`


### PR DESCRIPTION
## ⛳️작업 내용

App에서 SafeArea bottom이 없어져, CTA 버튼이 너무 하단에 위치하거나

크기 100%가 전체 높이를 나타내지 않아 `flex-grow`가 적용되지 않았던 문제를 해결했어요

- `signup/eamil-verified` route의 최상단 wrapper에 `padding-bottom: 32px`을 추가, `height: ${fullViewHeight()}`를 적용했어요

- `singup/information` route의 최상단 wrapper에 `padding-bottom: 32px`을 추가했어요

> `CTABottomButton`이 ios 환경일 경우 하단 패딩 8px을 갖기 때문에, 32px을 넣었어요 (디자인상 높이가 40px임니다)

## 📸스크린샷

<p>

<img src="https://user-images.githubusercontent.com/26461307/181500971-57da9d80-50be-4f71-85e5-4028bd0f7bea.png" alt="email-verified" width="40%" />

<img src="https://user-images.githubusercontent.com/26461307/181500959-8cacb0a1-58c3-4d4f-99a9-d73e69d8df9c.png" alt="information" width="40%" />

</p>


## ⚡️사용 방법

<!-- 공통 asset의 경우 사용법을 간략하게 적어봅시다 -->

## 📎레퍼런스

<!-- 참고한 레퍼런스가 있다면 기록해주세요 -->

<!--
리뷰어
혜성 : hyesungoh
도현 : ddarkr
대윤 : SenseCodeValue
은정 : positiveko
-->

closes #475 
