### PR TITLE
전체보기 이미지 layout 트랜지션 삭제

### DIFF
--- a/src/components/common/ImageContent.tsx
+++ b/src/components/common/ImageContent.tsx
@@ -14,7 +14,6 @@ import { IconButton } from './Button';
 import { CancelIcon } from './icons';
 import { dimBackdropCss } from './styles';
 
-const IMG_LAYOUT_ID = 'content_image';
 interface ImageContentProps {
   alt: string;
   src: string | null;
@@ -47,13 +46,7 @@ export default function ImageContent({
               </label>
             )}
 
-            <motion.img
-              layoutId={IMG_LAYOUT_ID}
-              src={src}
-              css={imgCss}
-              alt={alt}
-              onClick={toggleIsOpen}
-            />
+            <motion.img src={src} css={imgCss} alt={alt} onClick={toggleIsOpen} />
 
             <OpenedImageContent isOpen={isOpen} toggleIsOpen={toggleIsOpen} src={src} alt={alt} />
           </>
@@ -178,14 +171,7 @@ function OpenedImageContent({ isOpen, toggleIsOpen, src, alt }: OpenedImageConte
             </motion.div>
 
             <QuickPinchZoom onUpdate={onUpdate}>
-              <motion.img
-                ref={imgRef}
-                layoutId={IMG_LAYOUT_ID}
-                src={src}
-                css={opendImgCss}
-                alt={alt}
-                onClick={toggleIsOpen}
-              />
+              <img ref={imgRef} src={src} css={opendImgCss} alt={alt} onClick={toggleIsOpen} />
             </QuickPinchZoom>
           </motion.div>
         )}


### PR DESCRIPTION
## ⛳️작업 내용

#480 의 3번째 시도입니다 ....

css의 문제는 아닌 것으로 파악되어 `framer-motion`의 layout 애니메이션이 다음 후보가 되어 .. 걷어내봤어요

> 이것도 아니면 `QuickPinchZoom`이 문제일 거 같아요...!

## 📸스크린샷

<!-- 스크린샷으로 작업한 사항을 보여주세요 -->

## ⚡️사용 방법

<!-- 공통 asset의 경우 사용법을 간략하게 적어봅시다 -->

## 📎레퍼런스

<!-- 참고한 레퍼런스가 있다면 기록해주세요 -->

<!--
리뷰어
혜성 : hyesungoh
도현 : ddarkr
대윤 : SenseCodeValue
은정 : positiveko
-->
