### PR TITLE
clipboard로 영감 추가하기 기능

### DIFF
--- a/src/components/common/ToastSection.tsx
+++ b/src/components/common/ToastSection.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import Router from 'next/router';
 import { css, Theme, useTheme } from '@emotion/react';
 import { AnimatePresence, motion } from 'framer-motion';
@@ -18,8 +18,16 @@ export default function ToastSection() {
     setClipboardToastVisible(true);
   }, [currentToast?.content]);
 
-  const onClick = (e: React.MouseEvent<HTMLElement, MouseEvent>) => {
-    e.preventDefault();
+  const onClickClipboardToast = () => {
+    setClipboardToastVisible(false);
+    Router.push({
+      pathname: currentToast?.clipboardConfig?.type === 'TEXT' ? '/add/text' : '/add/link',
+      query: { isClipboard: true },
+    });
+  };
+
+  const onClickCloseButton = (e: React.MouseEvent<HTMLElement, MouseEvent>) => {
+    e.stopPropagation();
     setClipboardToastVisible(false);
   };
 
@@ -30,13 +38,7 @@ export default function ToastSection() {
           (!isNil(currentToast.clipboardConfig) ? (
             isClipboardToastVisible && (
               <motion.div
-                onClick={() =>
-                  Router.push({
-                    pathname:
-                      currentToast.clipboardConfig?.type === 'TEXT' ? '/add/text' : '/add/link',
-                    query: { isClipboard: true },
-                  })
-                }
+                onClick={onClickClipboardToast}
                 key={currentToast.content}
                 variants={defaultFadeInUpVariants}
                 initial="initial"
@@ -45,7 +47,7 @@ export default function ToastSection() {
                 css={clipboardToastCss}
               >
                 <span>{currentToast.content}</span>
-                <button onClick={onClick}>
+                <button onClick={onClickCloseButton}>
                   <CloseIcon isUsingFill color={theme.color.background} />
                 </button>
               </motion.div>

--- a/src/components/common/ToastSection.tsx
+++ b/src/components/common/ToastSection.tsx
@@ -1,17 +1,16 @@
 import { useEffect, useState } from 'react';
+import Router from 'next/router';
 import { css, Theme, useTheme } from '@emotion/react';
 import { AnimatePresence, motion } from 'framer-motion';
 import { isNil } from 'lodash';
 
 import { defaultFadeInUpVariants } from '~/constants/motions';
-import useInternalRouter from '~/hooks/common/useInternalRouter';
 import { useToast } from '~/store/Toast';
 
 import { CloseIcon } from './icons';
 
 export default function ToastSection() {
   const { currentToast } = useToast();
-  const { push } = useInternalRouter();
   const theme = useTheme();
   const [isClipboardToastVisible, setClipboardToastVisible] = useState(true);
 
@@ -32,7 +31,11 @@ export default function ToastSection() {
             isClipboardToastVisible && (
               <motion.div
                 onClick={() =>
-                  push(currentToast.clipboardConfig?.type === 'TEXT' ? '/add/text' : '/add/link')
+                  Router.push({
+                    pathname:
+                      currentToast.clipboardConfig?.type === 'TEXT' ? '/add/text' : '/add/link',
+                    query: { isClipboard: true },
+                  })
                 }
                 key={currentToast.content}
                 variants={defaultFadeInUpVariants}

--- a/src/components/common/ToastSection.tsx
+++ b/src/components/common/ToastSection.tsx
@@ -4,18 +4,25 @@ import { AnimatePresence, motion } from 'framer-motion';
 import { isNil } from 'lodash';
 
 import { defaultFadeInUpVariants } from '~/constants/motions';
+import useInternalRouter from '~/hooks/common/useInternalRouter';
 import { useToast } from '~/store/Toast';
 
 import { CloseIcon } from './icons';
 
 export default function ToastSection() {
   const { currentToast } = useToast();
+  const { push } = useInternalRouter();
   const theme = useTheme();
   const [isClipboardToastVisible, setClipboardToastVisible] = useState(true);
 
   useEffect(() => {
     setClipboardToastVisible(true);
   }, [currentToast?.content]);
+
+  const onClick = (e: React.MouseEvent<HTMLElement, MouseEvent>) => {
+    e.preventDefault();
+    setClipboardToastVisible(false);
+  };
 
   return (
     <div css={wrapperCss}>
@@ -24,6 +31,9 @@ export default function ToastSection() {
           (!isNil(currentToast.clipboardConfig) ? (
             isClipboardToastVisible && (
               <motion.div
+                onClick={() =>
+                  push(currentToast.clipboardConfig?.type === 'TEXT' ? '/add/text' : '/add/link')
+                }
                 key={currentToast.content}
                 variants={defaultFadeInUpVariants}
                 initial="initial"
@@ -32,7 +42,7 @@ export default function ToastSection() {
                 css={clipboardToastCss}
               >
                 <span dangerouslySetInnerHTML={{ __html: currentToast.content }} />
-                <button onClick={() => setClipboardToastVisible(false)}>
+                <button onClick={onClick}>
                   <CloseIcon isUsingFill color={theme.color.background} />
                 </button>
               </motion.div>

--- a/src/components/common/ToastSection.tsx
+++ b/src/components/common/ToastSection.tsx
@@ -44,7 +44,7 @@ export default function ToastSection() {
                 exit="exit"
                 css={clipboardToastCss}
               >
-                <span dangerouslySetInnerHTML={{ __html: currentToast.content }} />
+                <span>{currentToast.content}</span>
                 <button onClick={onClick}>
                   <CloseIcon isUsingFill color={theme.color.background} />
                 </button>
@@ -103,5 +103,6 @@ const clipboardToastCss = (theme: Theme) => css`
     flex-grow: 1;
     text-align: left;
     line-height: 140%;
+    white-space: pre-wrap;
   }
 `;

--- a/src/components/common/ToastSection.tsx
+++ b/src/components/common/ToastSection.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useState } from 'react';
 import Router from 'next/router';
 import { css, Theme, useTheme } from '@emotion/react';
 import { AnimatePresence, motion } from 'framer-motion';
-import { isNil } from 'lodash';
+import isNil from 'lodash/isNil';
 
 import { defaultFadeInUpVariants } from '~/constants/motions';
 import { useToast } from '~/store/Toast';

--- a/src/components/common/ToastSection.tsx
+++ b/src/components/common/ToastSection.tsx
@@ -1,27 +1,54 @@
-import { css, Theme } from '@emotion/react';
+import { useEffect, useState } from 'react';
+import { css, Theme, useTheme } from '@emotion/react';
 import { AnimatePresence, motion } from 'framer-motion';
+import { isNil } from 'lodash';
 
 import { defaultFadeInUpVariants } from '~/constants/motions';
 import { useToast } from '~/store/Toast';
 
+import { CloseIcon } from './icons';
+
 export default function ToastSection() {
   const { currentToast } = useToast();
+  const theme = useTheme();
+  const [isClipboardToastVisible, setClipboardToastVisible] = useState(true);
+
+  useEffect(() => {
+    setClipboardToastVisible(true);
+  }, [currentToast?.content]);
 
   return (
     <div css={wrapperCss}>
       <AnimatePresence exitBeforeEnter>
-        {currentToast && (
-          <motion.div
-            key={currentToast.content}
-            variants={defaultFadeInUpVariants}
-            initial="initial"
-            animate="animate"
-            exit="exit"
-            css={toastCss}
-          >
-            {currentToast.content}
-          </motion.div>
-        )}
+        {currentToast &&
+          (!isNil(currentToast.clipboardConfig) ? (
+            isClipboardToastVisible && (
+              <motion.div
+                key={currentToast.content}
+                variants={defaultFadeInUpVariants}
+                initial="initial"
+                animate="animate"
+                exit="exit"
+                css={clipboardToastCss}
+              >
+                <span dangerouslySetInnerHTML={{ __html: currentToast.content }} />
+                <button onClick={() => setClipboardToastVisible(false)}>
+                  <CloseIcon isUsingFill color={theme.color.background} />
+                </button>
+              </motion.div>
+            )
+          ) : (
+            <motion.div
+              key={currentToast.content}
+              variants={defaultFadeInUpVariants}
+              initial="initial"
+              animate="animate"
+              exit="exit"
+              css={toastCss}
+            >
+              {currentToast.content}
+            </motion.div>
+          ))}
       </AnimatePresence>
     </div>
   );
@@ -48,4 +75,20 @@ const toastCss = (theme: Theme) => css`
   padding: 16px;
   text-align: center;
   border-radius: ${theme.borderRadius.default};
+`;
+
+const clipboardToastCss = (theme: Theme) => css`
+  display: flex;
+  align-items: center;
+  font-size: 14px;
+  color: ${theme.color.background};
+  background-color: ${theme.color.gray06};
+  padding: 16px;
+  border-radius: ${theme.borderRadius.default};
+
+  span {
+    flex-grow: 1;
+    text-align: left;
+    line-height: 140%;
+  }
 `;

--- a/src/components/home/ClipboardAppMessageListener.tsx
+++ b/src/components/home/ClipboardAppMessageListener.tsx
@@ -1,3 +1,5 @@
+import { useRef } from 'react';
+
 import { AppMessageListener } from '~/hooks/bridge/useAppMessage';
 import { WEBVIEW_MESSAGE_TYPE } from '~/hooks/bridge/useAppMessage/useAppMessage';
 import { useToast } from '~/store/Toast';
@@ -9,11 +11,14 @@ interface ClipboardAppMessageListenerProps {
 
 export function ClipboardAppMessageListener({ children }: ClipboardAppMessageListenerProps) {
   const { fireToast } = useToast();
+  const prevClipboardData = useRef('');
 
   const makeClipboardToastMessage = (clipboardData: string): string => {
     const message =
       clipboardData.length > 18 ? `${clipboardData.substring(0, 18)}...` : clipboardData;
     const isLinkType = validator({ value: clipboardData, type: 'exactUrl' });
+    prevClipboardData.current = clipboardData;
+
     if (isLinkType) {
       return `복사한 링크 영감으로 추가하기`;
     }
@@ -24,6 +29,8 @@ export function ClipboardAppMessageListener({ children }: ClipboardAppMessageLis
     <AppMessageListener
       targetType={WEBVIEW_MESSAGE_TYPE.CLIPBOARD_INSPIRATION}
       handler={({ data }) => {
+        if (prevClipboardData.current === data) return;
+
         fireToast({
           content: makeClipboardToastMessage(`${data}`),
           duration: 3000,

--- a/src/components/home/ClipboardAppMessageListener.tsx
+++ b/src/components/home/ClipboardAppMessageListener.tsx
@@ -13,7 +13,7 @@ export function ClipboardAppMessageListener({ children }: ClipboardAppMessageLis
   const makeClipboardToastMessage = (clipboardData: string): string => {
     const message =
       clipboardData.length > 18 ? `${clipboardData.substring(0, 18)}...` : clipboardData;
-    const isLinkType = validator({ value: clipboardData, type: 'url' });
+    const isLinkType = validator({ value: clipboardData, type: 'exactUrl' });
     if (isLinkType) {
       return `복사한 링크 영감으로 추가하기`;
     }
@@ -28,7 +28,7 @@ export function ClipboardAppMessageListener({ children }: ClipboardAppMessageLis
           content: makeClipboardToastMessage(`${data}`),
           duration: 3000,
           clipboardConfig: {
-            type: validator({ value: `${data}`, type: 'url' }) ? 'LINK' : 'TEXT',
+            type: validator({ value: `${data}`, type: 'exactUrl' }) ? 'LINK' : 'TEXT',
             clipboardData: `${data}`,
           },
         });

--- a/src/components/home/ClipboardAppMessageListener.tsx
+++ b/src/components/home/ClipboardAppMessageListener.tsx
@@ -1,0 +1,32 @@
+import { AppMessageListener } from '~/hooks/bridge/useAppMessage';
+import { WEBVIEW_MESSAGE_TYPE } from '~/hooks/bridge/useAppMessage/useAppMessage';
+import { useToast } from '~/store/Toast';
+import { validator } from '~/utils/validator';
+
+interface ClipboardAppMessageListenerProps {
+  children: React.ReactNode;
+}
+
+export function ClipboardAppMessageListener({ children }: ClipboardAppMessageListenerProps) {
+  const { fireToast } = useToast();
+
+  const makeClipboardToastMessage = (clipboardData: string): string => {
+    const message =
+      clipboardData.length > 15 ? `${clipboardData.substring(0, 15)}...` : clipboardData;
+    if (validator({ value: clipboardData, type: 'url' })) {
+      return `복사한 링크 영감으로 추가하기`;
+    }
+    return `복사한 '${message}' 글 영감으로 추가하기`;
+  };
+
+  return (
+    <AppMessageListener
+      targetType={WEBVIEW_MESSAGE_TYPE.CLIPBOARD_INSPIRATION}
+      handler={({ data }) => {
+        fireToast({ content: makeClipboardToastMessage(`${data}`), duration: 3000 });
+      }}
+    >
+      {children}
+    </AppMessageListener>
+  );
+}

--- a/src/components/home/ClipboardAppMessageListener.tsx
+++ b/src/components/home/ClipboardAppMessageListener.tsx
@@ -15,7 +15,7 @@ export function ClipboardAppMessageListener({ children }: ClipboardAppMessageLis
 
   const makeClipboardToastMessage = (clipboardData: string): string => {
     const clipboardDataWithoutSpace = clipboardData.replace(/\n\s+/g, ' ').trim();
-    const message =
+    const toastMessage =
       clipboardData.length > 18
         ? `${clipboardDataWithoutSpace.substring(0, 18)}...`
         : clipboardDataWithoutSpace;
@@ -25,7 +25,7 @@ export function ClipboardAppMessageListener({ children }: ClipboardAppMessageLis
     if (isLinkType) {
       return `복사한 링크 영감으로 추가하기`;
     }
-    return `복사한 '${message}...'\n글 영감으로 추가하기`;
+    return `복사한 '${toastMessage}...'\n글 영감으로 추가하기`;
   };
 
   return (

--- a/src/components/home/ClipboardAppMessageListener.tsx
+++ b/src/components/home/ClipboardAppMessageListener.tsx
@@ -12,18 +12,26 @@ export function ClipboardAppMessageListener({ children }: ClipboardAppMessageLis
 
   const makeClipboardToastMessage = (clipboardData: string): string => {
     const message =
-      clipboardData.length > 15 ? `${clipboardData.substring(0, 15)}...` : clipboardData;
-    if (validator({ value: clipboardData, type: 'url' })) {
+      clipboardData.length > 18 ? `${clipboardData.substring(0, 18)}...` : clipboardData;
+    const isLinkType = validator({ value: clipboardData, type: 'url' });
+    if (isLinkType) {
       return `복사한 링크 영감으로 추가하기`;
     }
-    return `복사한 '${message}' 글 영감으로 추가하기`;
+    return `복사한 '${message}...'<br/>글 영감으로 추가하기`;
   };
 
   return (
     <AppMessageListener
       targetType={WEBVIEW_MESSAGE_TYPE.CLIPBOARD_INSPIRATION}
       handler={({ data }) => {
-        fireToast({ content: makeClipboardToastMessage(`${data}`), duration: 3000 });
+        fireToast({
+          content: makeClipboardToastMessage(`${data}`),
+          duration: 3000,
+          clipboardConfig: {
+            type: validator({ value: `${data}`, type: 'url' }) ? 'LINK' : 'TEXT',
+            clipboardData: `${data}`,
+          },
+        });
       }}
     >
       {children}

--- a/src/components/home/ClipboardAppMessageListener.tsx
+++ b/src/components/home/ClipboardAppMessageListener.tsx
@@ -14,15 +14,18 @@ export function ClipboardAppMessageListener({ children }: ClipboardAppMessageLis
   const prevClipboardData = useRef('');
 
   const makeClipboardToastMessage = (clipboardData: string): string => {
+    const clipboardDataWithoutSpace = clipboardData.replace(/\n\s+/g, ' ').trim();
     const message =
-      clipboardData.length > 18 ? `${clipboardData.substring(0, 18)}...` : clipboardData;
+      clipboardData.length > 18
+        ? `${clipboardDataWithoutSpace.substring(0, 18)}...`
+        : clipboardDataWithoutSpace;
     const isLinkType = validator({ value: clipboardData, type: 'exactUrl' });
     prevClipboardData.current = clipboardData;
 
     if (isLinkType) {
       return `복사한 링크 영감으로 추가하기`;
     }
-    return `복사한 '${message}...'<br/>글 영감으로 추가하기`;
+    return `복사한 '${message}...'\n글 영감으로 추가하기`;
   };
 
   return (

--- a/src/hooks/bridge/useAppMessage/useAppMessage.ts
+++ b/src/hooks/bridge/useAppMessage/useAppMessage.ts
@@ -1,10 +1,11 @@
 import { useCallback } from 'react';
 
-const WEBVIEW_MESSAGE_TYPE = {
+export const WEBVIEW_MESSAGE_TYPE = {
   CREATED_INSPIRATION: 'CreatedInspiration',
   CLOSED_INSPIRATION: 'ClosedInspiration',
   SEND_TOAST_MESSAGE: 'SendToastMessage',
   SHARE_EXTENTION_MESSAGE_TYPE: 'YgtangAppShareData',
+  CLIPBOARD_INSPIRATION: 'ClipboardInspiration',
 } as const;
 
 type WebviewMessageTypeKey = keyof typeof WEBVIEW_MESSAGE_TYPE;

--- a/src/pages/add/link.tsx
+++ b/src/pages/add/link.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import dynamic from 'next/dynamic';
 import { css } from '@emotion/react';
 
@@ -12,6 +12,7 @@ import { MemoText } from '~/components/common/TextField';
 import useInspirationMutation from '~/hooks/api/inspiration/useInspirationMutation';
 import { useDataShareMessage } from '~/hooks/common/useDataShareMessage';
 import useInput from '~/hooks/common/useInput';
+import useQueryParam from '~/hooks/common/useRouterQuery';
 import { useAppliedTags } from '~/store/AppliedTags';
 import { useToast } from '~/store/Toast';
 import { recordEvent } from '~/utils/analytics';
@@ -21,17 +22,22 @@ import { formCss } from './image';
 const AddTagFormRouteAsModal = dynamic(() => import('~/components/add/AddTagFormRouteAsModal'));
 
 export default function AddLink() {
+  const isClipboard = useQueryParam('isClipboard', String);
   const {
     onChange: onMemoChange,
     debouncedValue: memoDebouncedValue,
     value: memoValue,
   } = useInput({ useDebounce: true });
-
+  const { currentToast, fireToast } = useToast();
   const [openGraph, setOpenGraph] = useState<OpenGraphResponse | null>(null);
   const [initialLink, setInitialLink] = useState('');
 
+  useEffect(() => {
+    if (isClipboard !== 'true') return;
+    setInitialLink(currentToast?.clipboardConfig?.clipboardData ?? '');
+  }, [isClipboard, currentToast]);
+
   useDataShareMessage({ type: 'LINK', setStateHandler: setInitialLink });
-  const { fireToast } = useToast();
 
   const onMutationError = () => {
     fireToast({ content: '오류가 발생했습니다. 다시 시도해주세요.', duration: 3500 });

--- a/src/pages/add/link.tsx
+++ b/src/pages/add/link.tsx
@@ -33,8 +33,9 @@ export default function AddLink() {
   const [initialLink, setInitialLink] = useState('');
 
   useEffect(() => {
-    if (isClipboard !== 'true') return;
-    setInitialLink(currentToast?.clipboardConfig?.clipboardData ?? '');
+    const clipboardLink = currentToast?.clipboardConfig?.clipboardData;
+    if (clipboardLink === undefined || isClipboard !== 'true') return;
+    setInitialLink(clipboardLink);
   }, [isClipboard, currentToast]);
 
   useDataShareMessage({ type: 'LINK', setStateHandler: setInitialLink });

--- a/src/pages/add/text.tsx
+++ b/src/pages/add/text.tsx
@@ -1,3 +1,4 @@
+import { useEffect } from 'react';
 import dynamic from 'next/dynamic';
 import { css } from '@emotion/react';
 
@@ -11,6 +12,7 @@ import { Input } from '~/components/common/TextField/Input';
 import useInspirationMutation from '~/hooks/api/inspiration/useInspirationMutation';
 import { useDataShareMessage } from '~/hooks/common/useDataShareMessage';
 import useInput from '~/hooks/common/useInput';
+import useQueryParam from '~/hooks/common/useRouterQuery';
 import { useAppliedTags } from '~/store/AppliedTags';
 import { useToast } from '~/store/Toast';
 import { recordEvent } from '~/utils/analytics';
@@ -20,11 +22,18 @@ import { formCss } from './image';
 const AddTagFormRouteAsModal = dynamic(() => import('~/components/add/AddTagFormRouteAsModal'));
 
 export default function AddText() {
+  const isClipboard = useQueryParam('isClipboard', String);
+  const { currentToast } = useToast();
   const inspiringText = useInput({ useDebounce: true });
   const memoText = useInput({ useDebounce: true });
   const isEmptyText = !Boolean(inspiringText.debouncedValue.trim());
   const { tags } = useAppliedTags(true);
   const { fireToast } = useToast();
+
+  useEffect(() => {
+    if (isClipboard !== 'true') return;
+    inspiringText.setValue(currentToast?.clipboardConfig?.clipboardData ?? '');
+  }, [isClipboard, currentToast, inspiringText]);
 
   useDataShareMessage({ type: 'TEXT', setStateHandler: inspiringText.setValue });
 
@@ -68,6 +77,9 @@ export default function AddText() {
                 placeholder="영감을 작성해 보세요."
                 value={inspiringText.value}
                 onChange={inspiringText.onChange}
+                defaultValue={
+                  isClipboard === 'true' ? currentToast?.clipboardConfig?.clipboardData : undefined
+                }
               />
             </div>
             <div css={contentWrapperCss}>

--- a/src/pages/add/text.tsx
+++ b/src/pages/add/text.tsx
@@ -31,8 +31,9 @@ export default function AddText() {
   const { fireToast } = useToast();
 
   useEffect(() => {
-    if (isClipboard !== 'true') return;
-    inspiringText.setValue(currentToast?.clipboardConfig?.clipboardData ?? '');
+    const clipboardText = currentToast?.clipboardConfig?.clipboardData;
+    if (clipboardText === undefined || isClipboard !== 'true') return;
+    inspiringText.setValue(clipboardText);
   }, [isClipboard, currentToast, inspiringText]);
 
   useDataShareMessage({ type: 'TEXT', setStateHandler: inspiringText.setValue });

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -6,6 +6,7 @@ import LoadingHandler from '~/components/common/LoadingHandler';
 import { FixedSpinner } from '~/components/common/Spinner';
 import AppliedTags from '~/components/common/TagForm/AppliedTags';
 import AppendButton from '~/components/home/AppendButton';
+import { ClipboardAppMessageListener } from '~/components/home/ClipboardAppMessageListener';
 import EmptyImageSection from '~/components/home/EmptyImageSection';
 import HomeNavigationBar from '~/components/home/HomeNavigationBar';
 import Thumbnail from '~/components/home/Thumbnail';
@@ -34,7 +35,7 @@ export default function Root() {
   });
 
   return (
-    <>
+    <ClipboardAppMessageListener>
       <HomeNavigationBar />
       <motion.article layout>
         {filteredTags.length > 0 && (
@@ -76,7 +77,7 @@ export default function Root() {
 
       <InspirationViewAsModal />
       <EditTagFormRouteAsModal />
-    </>
+    </ClipboardAppMessageListener>
   );
 }
 

--- a/src/store/Toast/toastStates.ts
+++ b/src/store/Toast/toastStates.ts
@@ -1,9 +1,14 @@
 import { atom } from 'recoil';
 
+export interface ClipboardConfig {
+  type: InspirationType;
+  clipboardData: string;
+}
 export interface ToastInterface {
   key?: string;
   content: string;
   duration?: number;
+  clipboardConfig?: ClipboardConfig;
 }
 
 export const toastMessageState = atom<ToastInterface | null>({

--- a/src/store/Toast/useToast.ts
+++ b/src/store/Toast/useToast.ts
@@ -28,7 +28,7 @@ export function useToast() {
     },
     [removeToast, setCurrentToast]
   );
-  return { currentToast, fireToast, removeToast };
+  return { currentToast, fireToast };
 }
 
 function getKey() {

--- a/src/store/Toast/useToast.ts
+++ b/src/store/Toast/useToast.ts
@@ -22,13 +22,13 @@ export function useToast() {
   );
 
   const fireToast = useCallback(
-    ({ key = getKey(), content, duration = DEFAULT_DURATION }: ToastInterface) => {
-      setCurrentToast({ key, content, duration });
+    ({ key = getKey(), content, duration = DEFAULT_DURATION, clipboardConfig }: ToastInterface) => {
+      setCurrentToast({ key, content, duration, clipboardConfig });
       setTimeout(() => removeToast(key), duration);
     },
     [removeToast, setCurrentToast]
   );
-  return { currentToast, fireToast };
+  return { currentToast, fireToast, removeToast };
 }
 
 function getKey() {

--- a/src/utils/validator.ts
+++ b/src/utils/validator.ts
@@ -1,4 +1,4 @@
-type ValidatorType = 'email' | 'url';
+type ValidatorType = 'email' | 'url' | 'exactUrl';
 
 interface Validator {
   /**
@@ -21,6 +21,8 @@ const pattern: Record<ValidatorType, RegExp> = {
   email:
     /^(([^<>()\[\]\\.,;:\s@"]+(\.[^<>()\[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}])|(([a-zA-Z\-0-9\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF]+\.)+[a-zA-Z\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF]{2,}))$/,
   url: /(http(s)?:\/\/.)?(www\.)?[-a-zA-Z0-9@:%._\+~#=]{2,256}\.[a-z]{2,9}\b([-a-zA-Z0-9@:%_\+.~#?&/=]*)/g,
+  exactUrl:
+    /(http(s)?:\/\/.)(www\.)?[-a-zA-Z0-9@:%._\+~#=]{2,256}\.[a-z]{2,9}\b([-a-zA-Z0-9@:%_\+.~#?&/=]*)/g,
 };
 
 export const validator = ({ value, type, rule }: Validator) => {


### PR DESCRIPTION
## ⛳️작업 내용
### 클립보드 앱 메시지 리스너, 클립보드 토스트 추가
기존 토스트 섹션에서 클립보드용 토스트를 추가했습니다. 클립보드 앱 메시지 리스너는 홈 화면에만 들어갑니다.
### exactUrl validator 추가
기존 url validator로는 다양한 상황에서 텍스트 영감을 링크 영감 타입으로 처리할 가능성이 높습니다. https로 시작해야만 링크 영감으로 분류되도록 했습니다.
<!-- 작업한 사항을 간략하게 적어주세요 -->

## 📸스크린샷
![image](https://user-images.githubusercontent.com/69200669/184572980-46ad0f2c-e363-4625-8bd4-1812ed8d4484.png)
![image](https://user-images.githubusercontent.com/69200669/184573004-1a50b9b1-d2ab-48a5-b86d-51402038979f.png)

<!-- 스크린샷으로 작업한 사항을 보여주세요 -->

## ⚡️사용 방법

<!-- 공통 asset의 경우 사용법을 간략하게 적어봅시다 -->

## 📎레퍼런스

<!-- 참고한 레퍼런스가 있다면 기록해주세요 -->

<!--
리뷰어
혜성 : hyesungoh
도현 : ddarkr
대윤 : SenseCodeValue
은정 : positiveko
-->
