### PR TITLE
Toast 메세지 배경 색상 변경

### DIFF
--- a/src/components/common/ToastSection.tsx
+++ b/src/components/common/ToastSection.tsx
@@ -44,7 +44,7 @@ const wrapperCss = (theme: Theme) => css`
 const toastCss = (theme: Theme) => css`
   font-size: 14px;
   color: ${theme.color.background};
-  background-color: ${theme.color.gray05};
+  background-color: ${theme.color.gray_toast};
   padding: 16px;
   text-align: center;
   border-radius: ${theme.borderRadius.default};

--- a/src/styles/Theme/Theme.ts
+++ b/src/styles/Theme/Theme.ts
@@ -11,6 +11,7 @@ const theme = {
     gray04: '#717D82',
     gray05: '#5A676A',
     gray06: '#2D2D2D', // main article text
+    gray_toast: '#424b4d',
     dim01: 'rgba(0, 0, 0, 0.1)', // main thumnail tag background
     dim02: 'rgba(0, 0, 0, 0.2)',
     dim03: 'rgba(0, 0, 0, 0.6)', //screen dim


### PR DESCRIPTION
## ⛳️작업 내용

<img width="808" alt="스크린샷 2022-09-13 오후 9 16 36" src="https://user-images.githubusercontent.com/26461307/189898597-8995957e-db8c-4732-82b6-347a23ccbd6b.png">


디자인 업데이트를 반영합니다.

## 📸스크린샷

<!-- 스크린샷으로 작업한 사항을 보여주세요 -->

## ⚡️사용 방법

<!-- 공통 asset의 경우 사용법을 간략하게 적어봅시다 -->

## 📎레퍼런스

<!-- 참고한 레퍼런스가 있다면 기록해주세요 -->

<!--
리뷰어
혜성 : hyesungoh
도현 : ddarkr
대윤 : SenseCodeValue
은정 : positiveko
-->

closes #486 
