### PR TITLE
iOS 환경 영감 종류 필터링 디자인 에러 수정

### DIFF
--- a/src/components/home/FilterBottomSheetModal/InspirationKindSection.tsx
+++ b/src/components/home/FilterBottomSheetModal/InspirationKindSection.tsx
@@ -11,7 +11,7 @@ export default function InspirationKindSection() {
       <span css={spanCss}>영감 종류</span>
       <div css={buttonWrapperCss}>
         <CheckboxButton text="전체" value={null} />
-        <span css={spanDividerCss} />
+        <div css={spanDividerCss}></div>
         <CheckboxButton text="이미지" value={'IMAGE'} />
         <CheckboxButton text="글" value={'TEXT'} />
         <CheckboxButton text="링크" value={'LINK'} />
@@ -32,6 +32,7 @@ const spanCss = css`
 
 const buttonWrapperCss = css`
   display: flex;
+  justify-content: flex-start;
   align-items: center;
   gap: 12px;
   height: 36px;
@@ -71,6 +72,7 @@ const buttonCss = (theme: Theme) => css`
   align-items: center;
   font-size: 12px;
   gap: 6px;
+  padding: 0;
   color: ${theme.color.gray05};
 
   /* NOTE: Check Icon 상하 가운데 정렬 */


### PR DESCRIPTION
## ⛳️작업 내용

<img src="https://user-images.githubusercontent.com/26461307/193526527-babe6332-f7c5-4d4a-b0d3-382906abfc43.png" width="30%" />


iOS 환경에서 flex 요소들이 예상치 못하게 나오는 환경을 대응했어요

> 시뮬레이터로 실행해 보아도 재현이 되지 않아 예상되는 것들로 대응해 봤어요

- `<span />` 태그를 `<div></div>` 태그로 수정
- `flex` 요소에 `justify-content` 속성 추가
<!-- 작업한 사항을 간략하게 적어주세요 -->

## 📸스크린샷

<!-- 스크린샷으로 작업한 사항을 보여주세요 -->

## ⚡️사용 방법

<!-- 공통 asset의 경우 사용법을 간략하게 적어봅시다 -->

## 📎레퍼런스

<!-- 참고한 레퍼런스가 있다면 기록해주세요 -->

<!--
리뷰어
혜성 : hyesungoh
도현 : ddarkr
대윤 : SenseCodeValue
은정 : positiveko
-->
