### PR TITLE
영감 조회시 생성 (업데이트) 시간 적용

### DIFF
--- a/src/components/inspiration/ImageView.tsx
+++ b/src/components/inspiration/ImageView.tsx
@@ -10,9 +10,13 @@ import useInput from '~/hooks/common/useInput';
 import { fullViewHeight } from '~/styles/utils';
 import { recordEvent } from '~/utils/analytics';
 
+import { ViewProps } from './type';
+
 const AddTagFormRouteAsModal = dynamic(() => import('~/components/add/AddTagFormRouteAsModal'));
 
-export default function ImageView({ inspiration }: { inspiration: InspirationInterface }) {
+interface ImageViewProps extends ViewProps {}
+
+export default function ImageView({ inspiration }: ImageViewProps) {
   const {
     onChange: onMemoChange,
     debouncedValue: memoDebouncedValue,

--- a/src/components/inspiration/ImageView.tsx
+++ b/src/components/inspiration/ImageView.tsx
@@ -10,6 +10,7 @@ import useInput from '~/hooks/common/useInput';
 import { fullViewHeight } from '~/styles/utils';
 import { recordEvent } from '~/utils/analytics';
 
+import InspirationTime from './InspirationTime';
 import { ViewProps } from './type';
 
 const AddTagFormRouteAsModal = dynamic(() => import('~/components/add/AddTagFormRouteAsModal'));
@@ -34,13 +35,14 @@ export default function ImageView({ inspiration }: ImageViewProps) {
 
   if (!inspiration) return <></>;
 
-  const { tagResponses, content } = inspiration;
+  const { tagResponses, content, updatedDatetime } = inspiration;
 
   return (
     <>
       <article css={addImageCss}>
         <div css={formCss}>
           <section css={addImageTopCss}>
+            <InspirationTime updatedDatetime={updatedDatetime} />
             <div css={contentWrapperCss}>
               <ImageContent src={content ?? null} alt="uploadedImg" />
             </div>

--- a/src/components/inspiration/InspirationTime.tsx
+++ b/src/components/inspiration/InspirationTime.tsx
@@ -1,0 +1,37 @@
+import { useMemo } from 'react';
+import { css, Theme } from '@emotion/react';
+
+interface InspirationTimeProps {
+  updatedDatetime: string;
+}
+
+const WEEK = ['일', '월', '화', '수', '목', '금', '토'];
+
+export default function InspirationTime({ updatedDatetime }: InspirationTimeProps) {
+  const formattedTime = useMemo(() => {
+    const updateDate = new Date(updatedDatetime);
+
+    const year = updateDate.getFullYear();
+    const month = updateDate.getMonth() + 1;
+    const date = updateDate.getDate();
+    const day = WEEK[updateDate.getDay()];
+    const time = updatedDatetime.slice(11, 16);
+
+    return `${year}년 ${month}월 ${date}일 (${day}) ${time}`;
+  }, [updatedDatetime]);
+
+  return (
+    <p css={timeCss}>
+      <time dateTime={updatedDatetime}>{formattedTime}</time>
+    </p>
+  );
+}
+
+const timeCss = (theme: Theme) => css`
+  margin-top: 16px;
+
+  text-align: right;
+  font-size: 12px;
+  color: ${theme.color.gray04};
+  line-height: 1.2;
+`;

--- a/src/components/inspiration/LinkView.tsx
+++ b/src/components/inspiration/LinkView.tsx
@@ -10,6 +10,7 @@ import useInput from '~/hooks/common/useInput';
 import { recordEvent } from '~/utils/analytics';
 
 import { formCss } from './ImageView';
+import InspirationTime from './InspirationTime';
 import { ViewProps } from './type';
 
 const AddTagFormRouteAsModal = dynamic(() => import('~/components/add/AddTagFormRouteAsModal'));
@@ -33,7 +34,7 @@ export default function LinkView({ inspiration }: LinkViewProps) {
   };
 
   if (!inspiration) return <></>;
-  const { tagResponses, openGraphResponse } = inspiration;
+  const { tagResponses, openGraphResponse, updatedDatetime } = inspiration;
 
   if (!openGraphResponse) return <></>;
 
@@ -44,6 +45,7 @@ export default function LinkView({ inspiration }: LinkViewProps) {
       <article css={addLinkCss}>
         <form css={formCss}>
           <section css={addLinkTopCss}>
+            <InspirationTime updatedDatetime={updatedDatetime} />
             <div css={contentWrapperCss}>
               <LinkInput
                 openGraph={{

--- a/src/components/inspiration/LinkView.tsx
+++ b/src/components/inspiration/LinkView.tsx
@@ -10,10 +10,13 @@ import useInput from '~/hooks/common/useInput';
 import { recordEvent } from '~/utils/analytics';
 
 import { formCss } from './ImageView';
+import { ViewProps } from './type';
 
 const AddTagFormRouteAsModal = dynamic(() => import('~/components/add/AddTagFormRouteAsModal'));
 
-export default function LinkView({ inspiration }: { inspiration: InspirationInterface }) {
+interface LinkViewProps extends ViewProps {}
+
+export default function LinkView({ inspiration }: LinkViewProps) {
   const {
     onChange: onMemoChange,
     debouncedValue: memoDebouncedValue,

--- a/src/components/inspiration/TextView.tsx
+++ b/src/components/inspiration/TextView.tsx
@@ -10,10 +10,13 @@ import useInput from '~/hooks/common/useInput';
 import { recordEvent } from '~/utils/analytics';
 
 import { formCss } from './ImageView';
+import { ViewProps } from './type';
 
 const AddTagFormRouteAsModal = dynamic(() => import('~/components/add/AddTagFormRouteAsModal'));
 
-export default function TextView({ inspiration }: { inspiration: InspirationInterface }) {
+interface TextViewProps extends ViewProps {}
+
+export default function TextView({ inspiration }: TextViewProps) {
   const inspiringText = useInput({ useDebounce: true });
   const memoText = useInput({ useDebounce: true, initialValue: inspiration.memo });
   const { modifyInspiration } = useInspirationMutation();

--- a/src/components/inspiration/TextView.tsx
+++ b/src/components/inspiration/TextView.tsx
@@ -10,6 +10,7 @@ import useInput from '~/hooks/common/useInput';
 import { recordEvent } from '~/utils/analytics';
 
 import { formCss } from './ImageView';
+import InspirationTime from './InspirationTime';
 import { ViewProps } from './type';
 
 const AddTagFormRouteAsModal = dynamic(() => import('~/components/add/AddTagFormRouteAsModal'));
@@ -31,13 +32,14 @@ export default function TextView({ inspiration }: TextViewProps) {
 
   if (!inspiration) return <></>;
 
-  const { tagResponses, content } = inspiration;
+  const { tagResponses, content, updatedDatetime } = inspiration;
 
   return (
     <>
       <article css={addTextCss}>
         <form css={formCss}>
           <section css={addTextTopCss}>
+            <InspirationTime updatedDatetime={updatedDatetime} />
             <div css={contentWrapperCss}>
               <Input
                 as="textarea"

--- a/src/components/inspiration/type.ts
+++ b/src/components/inspiration/type.ts
@@ -1,0 +1,3 @@
+export interface ViewProps {
+  inspiration: InspirationInterface;
+}


### PR DESCRIPTION
## ⛳️작업 내용

- 영감의 `updatedDatetime`을 주입받아 시간 형태로 렌더링하는 `InspirationTime` 컴포넌트를 개발, 적용했어요.
- `ImageView`, `TextView`, `LinkView`에서 국지적으로 선언되고 있던 props의 타입을 정의하고 확장하는 형태로 리팩토링했어요. c44b1df03056622ce6b59bd8e6608d85ede03065

## 📸스크린샷

<!-- 스크린샷으로 작업한 사항을 보여주세요 -->
![스크린샷 2022-10-11 오후 9 04 55](https://user-images.githubusercontent.com/26461307/195084869-488f5748-1bb0-4ae1-ad8f-586c0ac91abf.png)


## ⚡️사용 방법

<!-- 공통 asset의 경우 사용법을 간략하게 적어봅시다 -->

## 📎레퍼런스

- https://developer.mozilla.org/ko/docs/Web/HTML/Element/time

<!--
리뷰어
혜성 : hyesungoh
도현 : ddarkr
대윤 : SenseCodeValue
은정 : positiveko
-->

closes #494 