### PR TITLE
url surfix의 인식 범위를 2~9으로 늘림

### DIFF
--- a/src/utils/validator.ts
+++ b/src/utils/validator.ts
@@ -20,7 +20,7 @@ interface Validator {
 const pattern: Record<ValidatorType, RegExp> = {
   email:
     /^(([^<>()\[\]\\.,;:\s@"]+(\.[^<>()\[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}])|(([a-zA-Z\-0-9\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF]+\.)+[a-zA-Z\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF]{2,}))$/,
-  url: /(http(s)?:\/\/.)?(www\.)?[-a-zA-Z0-9@:%._\+~#=]{2,256}\.[a-z]{2,6}\b([-a-zA-Z0-9@:%_\+.~#?&/=]*)/g,
+  url: /(http(s)?:\/\/.)?(www\.)?[-a-zA-Z0-9@:%._\+~#=]{2,256}\.[a-z]{2,9}\b([-a-zA-Z0-9@:%_\+.~#?&/=]*)/g,
 };
 
 export const validator = ({ value, type, rule }: Validator) => {


### PR DESCRIPTION
## ⛳️작업 내용

<!-- 작업한 사항을 간략하게 적어주세요 -->

- `.academy`처럼 긴 surfix가 인식되지 않는 문제를 해결합니다.

## 📸스크린샷

<!-- 스크린샷으로 작업한 사항을 보여주세요 -->

<img width="673" alt="image" src="https://user-images.githubusercontent.com/6638675/197967588-110bcd64-aef4-46c4-817d-1a8483ed14e6.png">

![image](https://user-images.githubusercontent.com/6638675/197967714-a1196c97-23c5-4371-b1be-b586a1fe67f3.png)


## ⚡️사용 방법

<!-- 공통 asset의 경우 사용법을 간략하게 적어봅시다 -->

## 📎레퍼런스

<!-- 참고한 레퍼런스가 있다면 기록해주세요 -->

<!--
리뷰어
혜성 : hyesungoh
도현 : ddarkr
대윤 : SenseCodeValue
은정 : positiveko
-->
