### PR TITLE
모바일 공유하기 이후, 자동 닫히기

### DIFF
--- a/src/hooks/api/inspiration/useInspirationMutation.ts
+++ b/src/hooks/api/inspiration/useInspirationMutation.ts
@@ -53,7 +53,6 @@ export default function useInspirationMutation(param?: InspirationMutationParams
         fireToast({ content: '영감을 등록했습니다.' });
         resetInspirationList();
         postMessage(WEBVIEW_MESSAGE_TYPE.CreatedInspiration);
-        push('/');
       },
       onError: (error, variable, context) => {
         onError && onError();

--- a/src/hooks/common/useDataShareMessage.ts
+++ b/src/hooks/common/useDataShareMessage.ts
@@ -72,7 +72,9 @@ export function useDataShareMessage({
 
   const requestCompleteMessageWhenIosShare = (otherAction: VoidFunction) => {
     if (isIosShareView) {
-      sendShareCompleteMessage();
+      setTimeout(() => {
+        sendShareCompleteMessage();
+      }, 1000);
     } else {
       otherAction();
     }

--- a/src/hooks/common/useDataShareMessage.ts
+++ b/src/hooks/common/useDataShareMessage.ts
@@ -1,4 +1,4 @@
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 
 import { UploadedImg } from '~/store/UploadedImage/useUploadedImg';
 import { base64ToBlob } from '~/utils/common';
@@ -49,6 +49,7 @@ export function useDataShareMessage({
   setStateHandler,
 }: ImgShareMessageProps | DataShareMessageProps) {
   const { isAndroid, isIos, isMobile } = useUserAgent();
+  const [isIosShareView, setIsIosShareView] = useState(false);
 
   // NOTE : document.addEventListener('message', handleMessage)에 event type 중 MessageEvent 존재하지 않아 선대처합니다.
   const handleMessage = async (event: MessageEvent | unknown) => {
@@ -59,6 +60,21 @@ export function useDataShareMessage({
       setStateHandler({ blob: await base64ToBlob(data.data, data.mimeType), base64: data.data });
     } else {
       setStateHandler(data.data);
+    }
+    setIsIosShareView(isIos());
+  };
+
+  const sendShareCompleteMessage = () => {
+    window.ReactNativeWebView.postMessage(
+      JSON.stringify({ type: SHARE_WEB_MESSAGE_STATE, data: 'SHARE_COMPLETE' })
+    );
+  };
+
+  const requestCompleteMessageWhenIosShare = (otherAction: VoidFunction) => {
+    if (isIosShareView) {
+      sendShareCompleteMessage();
+    } else {
+      otherAction();
     }
   };
 
@@ -79,4 +95,8 @@ export function useDataShareMessage({
       target.removeEventListener('message', handleMessage);
     };
   });
+
+  return {
+    requestCompleteMessageWhenIosShare,
+  };
 }

--- a/src/pages/add/image.tsx
+++ b/src/pages/add/image.tsx
@@ -32,10 +32,13 @@ export default function AddImage() {
   } = useInput({ useDebounce: true });
   const { isDesktop } = useUserAgent();
   const { imgInputUploader } = useImgUpload({});
-  const { push } = useInternalRouter();
+  const { push, back } = useInternalRouter();
   const { uploadedImg, uploadImg } = useUploadedImg();
   const { fireToast } = useToast();
-  useDataShareMessage({ type: 'IMAGE', setStateHandler: uploadImg });
+  const { requestCompleteMessageWhenIosShare } = useDataShareMessage({
+    type: 'IMAGE',
+    setStateHandler: uploadImg,
+  });
 
   const onMutationError = () => {
     fireToast({ content: '오류가 발생했습니다. 다시 시도해주세요.', duration: 3500 });
@@ -71,13 +74,22 @@ export default function AddImage() {
         (memoValue.length > 0 ? '메모와 함께 영감 추가' : '메모없이 영감 추가') +
         ` 이미지 크기: ${uploadedImg.blob.size}`,
     });
-    createInspiration(imgData);
+    createInspiration(imgData, {
+      onSuccess: () => {
+        requestCompleteMessageWhenIosShare(() => push('/'));
+      },
+    });
   };
 
   return (
     <>
       <article css={addImageCss}>
-        <NavigationBar title="이미지 추가" />
+        <NavigationBar
+          title="이미지 추가"
+          onClickBackButton={() => {
+            requestCompleteMessageWhenIosShare(() => back());
+          }}
+        />
 
         <form onSubmit={submitImg} css={formCss}>
           <ImgUploader imgInputUploader={imgInputUploader} />

--- a/src/pages/add/link.tsx
+++ b/src/pages/add/link.tsx
@@ -12,6 +12,7 @@ import { MemoText } from '~/components/common/TextField';
 import useInspirationMutation from '~/hooks/api/inspiration/useInspirationMutation';
 import { useDataShareMessage } from '~/hooks/common/useDataShareMessage';
 import useInput from '~/hooks/common/useInput';
+import useInternalRouter from '~/hooks/common/useInternalRouter';
 import useQueryParam from '~/hooks/common/useRouterQuery';
 import { useAppliedTags } from '~/store/AppliedTags';
 import { useToast } from '~/store/Toast';
@@ -23,6 +24,7 @@ const AddTagFormRouteAsModal = dynamic(() => import('~/components/add/AddTagForm
 
 export default function AddLink() {
   const isClipboard = useQueryParam('isClipboard', String);
+  const { push, back } = useInternalRouter();
   const {
     onChange: onMemoChange,
     debouncedValue: memoDebouncedValue,
@@ -38,7 +40,10 @@ export default function AddLink() {
     setInitialLink(clipboardLink);
   }, [isClipboard, currentToast]);
 
-  useDataShareMessage({ type: 'LINK', setStateHandler: setInitialLink });
+  const { requestCompleteMessageWhenIosShare } = useDataShareMessage({
+    type: 'LINK',
+    setStateHandler: setInitialLink,
+  });
 
   const onMutationError = () => {
     fireToast({ content: '오류가 발생했습니다. 다시 시도해주세요.', duration: 3500 });
@@ -69,13 +74,22 @@ export default function AddLink() {
       value: '링크 영감',
       label: memoValue.length > 0 ? '메모와 함께 영감 추가' : '메모없이 영감 추가',
     });
-    createInspiration(linkData);
+    createInspiration(linkData, {
+      onSuccess: () => {
+        requestCompleteMessageWhenIosShare(() => push('/'));
+      },
+    });
   };
 
   return (
     <>
       <article css={addLinkCss}>
-        <NavigationBar title="링크 추가" />
+        <NavigationBar
+          title="링크 추가"
+          onClickBackButton={() => {
+            requestCompleteMessageWhenIosShare(() => back());
+          }}
+        />
 
         <form onSubmit={submitLink} css={formCss}>
           <section css={addLinkTopCss}>

--- a/src/pages/add/text.tsx
+++ b/src/pages/add/text.tsx
@@ -12,6 +12,7 @@ import { Input } from '~/components/common/TextField/Input';
 import useInspirationMutation from '~/hooks/api/inspiration/useInspirationMutation';
 import { useDataShareMessage } from '~/hooks/common/useDataShareMessage';
 import useInput from '~/hooks/common/useInput';
+import useInternalRouter from '~/hooks/common/useInternalRouter';
 import useQueryParam from '~/hooks/common/useRouterQuery';
 import { useAppliedTags } from '~/store/AppliedTags';
 import { useToast } from '~/store/Toast';
@@ -23,6 +24,7 @@ const AddTagFormRouteAsModal = dynamic(() => import('~/components/add/AddTagForm
 
 export default function AddText() {
   const isClipboard = useQueryParam('isClipboard', String);
+  const { push, back } = useInternalRouter();
   const { currentToast } = useToast();
   const inspiringText = useInput({ useDebounce: true });
   const memoText = useInput({ useDebounce: true });
@@ -36,7 +38,10 @@ export default function AddText() {
     inspiringText.setValue(clipboardText);
   }, [isClipboard, currentToast, inspiringText]);
 
-  useDataShareMessage({ type: 'TEXT', setStateHandler: inspiringText.setValue });
+  const { requestCompleteMessageWhenIosShare } = useDataShareMessage({
+    type: 'TEXT',
+    setStateHandler: inspiringText.setValue,
+  });
 
   const onMutationError = () => {
     fireToast({ content: '오류가 발생했습니다. 다시 시도해주세요.', duration: 3500 });
@@ -62,13 +67,22 @@ export default function AddText() {
       value: '텍스트 영감',
       label: memoText.value.length > 0 ? '메모와 함께 영감 추가' : '메모없이 영감 추가',
     });
-    createInspiration(textData);
+    createInspiration(textData, {
+      onSuccess: () => {
+        requestCompleteMessageWhenIosShare(() => push('/'));
+      },
+    });
   };
 
   return (
     <>
       <article css={addTextCss}>
-        <NavigationBar title="글 추가" />
+        <NavigationBar
+          title="글 추가"
+          onClickBackButton={() => {
+            requestCompleteMessageWhenIosShare(() => back());
+          }}
+        />
 
         <form onSubmit={submitText} css={formCss}>
           <section css={addTextTopCss}>


### PR DESCRIPTION
## ⛳️작업 내용
- 예전 '완료'로 작업되어 닫히던 코드가 사라지고 CTA버튼으로 바뀌면서 대응하지 않았던것을 적용했습니다.
- ios 일경우에만, 닫히면 됨으로 ios + share 상태인지 인지할 수 있도록했습니다.
  - 이후, ios + share 상태라면 completeMessage를 보내어 app에서 메시지를 통해 앱을 종료할 수 있도록했습니다.
  - 바로 닫히면 십버그같아서 1초의 delay를 주었습니다.
<!-- 작업한 사항을 간략하게 적어주세요 -->

연관 이슈 : https://github.com/depromeet/ygtang-app/issues/122

## 🚨 주의사항
ios 배포 이후 동작되는 코드입니다. 따라서 심사제출 시점에 머지되면 될것 같습니다!

## 📸스크린샷
https://user-images.githubusercontent.com/59507527/212136047-5ff8fb41-06ac-4cbd-ac3e-34b5e4bbadfb.mov
<!-- 스크린샷으로 작업한 사항을 보여주세요 -->

## ⚡️사용 방법
중복 되는 코드를 최대한 줄이고자 otherAction이라는 param을 받는 함수를 만들어 처리를 했습니다.
param 이름이 참...별로인듯
```ts
 const requestCompleteMessageWhenIosShare = (otherAction: VoidFunction) => {
    if (isIosShareView) {
      setTimeout(() => {
        sendShareCompleteMessage();
      }, 1000);
    } else {
      otherAction();
    }
  };
```
<!-- 공통 asset의 경우 사용법을 간략하게 적어봅시다 -->

## 📎레퍼런스
x
<!-- 참고한 레퍼런스가 있다면 기록해주세요 -->

<!--
리뷰어
혜성 : hyesungoh
도현 : ddarkr
대윤 : SenseCodeValue
은정 : positiveko
-->
