### PR TITLE
글자 영감과 메모 스타일 변경

### DIFF
--- a/src/components/common/TextField/MemoText.tsx
+++ b/src/components/common/TextField/MemoText.tsx
@@ -93,6 +93,7 @@ export function MemoText({
 
   return (
     <TextField
+      css={[editable && editableTextFieldCss]}
       as={'textarea'}
       value={value}
       onChange={onValueChange}
@@ -129,6 +130,12 @@ export function MemoText({
   );
 }
 
+const editableTextFieldCss = css`
+  padding: 0;
+  border: 0;
+  background-color: inherit;
+`;
+
 const flexBetweenWrapper = css`
   display: flex;
   justify-content: space-between;
@@ -146,6 +153,7 @@ const textLimitCss = (theme: Theme) => css`
   font-size: 12px;
   line-height: 150%;
 `;
+
 const textLimitCurrentCss = (theme: Theme) => css`
   color: ${theme.color.gray04};
 `;

--- a/src/components/inspiration/TextView.tsx
+++ b/src/components/inspiration/TextView.tsx
@@ -42,6 +42,7 @@ export default function TextView({ inspiration }: TextViewProps) {
             <InspirationTime updatedDatetime={updatedDatetime} />
             <div css={contentWrapperCss}>
               <Input
+                css={editableInputCss}
                 as="textarea"
                 placeholder="영감을 작성해 보세요."
                 value={content}
@@ -71,6 +72,12 @@ export default function TextView({ inspiration }: TextViewProps) {
     </>
   );
 }
+
+const editableInputCss = css`
+  border: 0;
+  padding: 0;
+  background-color: inherit;
+`;
 
 const addTextCss = css`
   display: flex;

--- a/src/pages/content/index.tsx
+++ b/src/pages/content/index.tsx
@@ -3,7 +3,6 @@ import dynamic from 'next/dynamic';
 import { motion } from 'framer-motion';
 
 import { FilledButton, IconButton } from '~/components/common/Button';
-import IllustDialog from '~/components/common/IllustDialog';
 import LoadingHandler from '~/components/common/LoadingHandler';
 import NavigationBar from '~/components/common/NavigationBar';
 import { FixedSpinner } from '~/components/common/Spinner';
@@ -18,6 +17,7 @@ import useQueryParam from '~/hooks/common/useRouterQuery';
 import { recordEvent } from '~/utils/analytics';
 
 const EditTagFormRouteAsModal = dynamic(() => import('~/components/edit/EditTagFormRouteAsModal'));
+const IllustDialog = dynamic(() => import('~/components/common/IllustDialog'));
 
 export default function ContentPage() {
   const inspirationId = useQueryParam('id', String);
@@ -80,30 +80,31 @@ export default function ContentPage() {
             {inspiration && renderInspirationViewByType(inspiration)}
           </motion.section>
         </LoadingHandler>
-
-        <IllustDialog
-          image={`/modal_characters/2.png`}
-          isShowing={isDeleteInspirationModalOn}
-          actionButtons={
-            <>
-              <FilledButton
-                colorType="light"
-                onClick={() => inspiration && deleteInspirationById(inspiration.id)}
-              >
-                네
-              </FilledButton>
-              <FilledButton colorType="dark" onClick={() => setDeleteInspirationModalOn(false)}>
-                아니요
-              </FilledButton>
-            </>
-          }
-        >
-          영감이 삭제됩니다.
-          <br />
-          괜찮으신가요?
-        </IllustDialog>
       </article>
+
       <EditTagFormRouteAsModal />
+
+      <IllustDialog
+        image={`/modal_characters/2.png`}
+        isShowing={isDeleteInspirationModalOn}
+        actionButtons={
+          <>
+            <FilledButton
+              colorType="light"
+              onClick={() => inspiration && deleteInspirationById(inspiration.id)}
+            >
+              네
+            </FilledButton>
+            <FilledButton colorType="dark" onClick={() => setDeleteInspirationModalOn(false)}>
+              아니요
+            </FilledButton>
+          </>
+        }
+      >
+        영감이 삭제됩니다.
+        <br />
+        괜찮으신가요?
+      </IllustDialog>
     </>
   );
 }


### PR DESCRIPTION
## ⛳️작업 내용

- close #497 
- 글자 영감 조회 시 변경된 디자인을 적용했어요
- 모든 종류의 영감의 메모 영역에 변견된 디자인을 적용했어요
- `/content`에서 일러스트 다이얼로그를 dynamic import 했어요

## 📸스크린샷
<img width="446" alt="스크린샷 2023-02-07 오후 3 52 39" src="https://user-images.githubusercontent.com/26461307/217169759-e551c92f-9796-43f6-8ad5-6645915b9dce.png">

<!-- 스크린샷으로 작업한 사항을 보여주세요 -->

## ⚡️사용 방법

<!-- 공통 asset의 경우 사용법을 간략하게 적어봅시다 -->

## 📎레퍼런스

<!-- 참고한 레퍼런스가 있다면 기록해주세요 -->

<!--
리뷰어
혜성 : hyesungoh
도현 : ddarkr
대윤 : SenseCodeValue
은정 : positiveko
-->
