### PR TITLE
무한 스크롤이 2번 실행되는 문제 해결

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "httpsdev": "node httpsDevServer.js",
     "build": "next build",
     "start": "next start",
+    "export": "next export",
     "lint": "next lint",
     "lint:fix": "eslint 'src/**/*.{js,jsx,ts,tsx}' --fix",
     "test": "jest --coverage",

--- a/src/hooks/common/useIntersectionObserver/useIntersectionObserver.ts
+++ b/src/hooks/common/useIntersectionObserver/useIntersectionObserver.ts
@@ -23,7 +23,8 @@ export default function useIntersectionObserver({
     observer.observe(target);
 
     return () => observer.unobserve(target);
-  }, [onIntersect, root, rootMargin, target, threshold]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [target]);
 
   return { setTarget };
 }


### PR DESCRIPTION
## ⛳️작업 내용

<!-- 작업한 사항을 간략하게 적어주세요 -->

- useIntersectionObserver에 작성되어 있는 useEffect 훅의 의존성에 의해서 발생하는 문제였습니다. 다만 올바른 수정인지는 의논이 필요해요.

## 📸스크린샷

<!-- 스크린샷으로 작업한 사항을 보여주세요 -->

## ⚡️사용 방법

<!-- 공통 asset의 경우 사용법을 간략하게 적어봅시다 -->

## 📎레퍼런스

<!-- 참고한 레퍼런스가 있다면 기록해주세요 -->

<!--
리뷰어
혜성 : hyesungoh
도현 : ddarkr
대윤 : SenseCodeValue
은정 : positiveko
-->
