### PR TITLE
링크 영감 OG 이미지 호출 시 무한 로딩

### DIFF
--- a/src/hooks/api/inspiration/useCheckLinkAvailable.ts
+++ b/src/hooks/api/inspiration/useCheckLinkAvailable.ts
@@ -72,6 +72,9 @@ export function useCheckLinkAvailable({ link }: UseCheckLinkAvailableProps) {
       isFetchedWith.current.http = true;
       return `http://${link}`;
     }
+
+    isFetchedWith.current.http = true;
+    isFetchedWith.current.https = true;
   };
 
   const fetchOpenGraph = (link: string): Promise<AxiosResponse<OpenGraphResponse>> => {
@@ -81,7 +84,6 @@ export function useCheckLinkAvailable({ link }: UseCheckLinkAvailableProps) {
 
   useDidUpdate(() => {
     if (!openGraph) return;
-
     // NOTE: openGraph가 재시도되면서 url 값이 있을 시 종료
     if (openGraph.url) {
       setIsCheckingLinkWithAllProtocol(true);

--- a/src/hooks/api/inspiration/useCheckLinkAvailable.ts
+++ b/src/hooks/api/inspiration/useCheckLinkAvailable.ts
@@ -4,6 +4,7 @@ import { AxiosResponse } from 'axios';
 
 import useDidUpdate from '~/hooks/common/useDidUpdate';
 import { get } from '~/libs/api/client';
+import { useToast } from '~/store/Toast';
 
 const INSPIRATION_LINK_OG_QUERY_KEY = 'opengraph';
 
@@ -12,17 +13,27 @@ interface UseCheckLinkAvailableProps {
 }
 
 export function useCheckLinkAvailable({ link }: UseCheckLinkAvailableProps) {
+  const { fireToast } = useToast();
+
   const {
     data: openGraph,
     refetch,
     remove,
     isFetching,
-  } = useQuery<OpenGraphResponse>(
+  } = useQuery<OpenGraphResponse, { message?: string }>(
     [INSPIRATION_LINK_OG_QUERY_KEY, link],
     () => fetchOpenGraph(link).then(res => res.data),
     {
       enabled: false,
       keepPreviousData: true,
+      onError: error => {
+        if (error) {
+          fireToast({
+            content: '서버에서 에러가 발생했습니다. 링크를 확인해주세요.',
+            duration: 2500,
+          });
+        }
+      },
     }
   );
 


### PR DESCRIPTION
## ⛳️작업 내용
기존 서버에서 data를 형태의 error를 뱉는것에서 error가 직접적으로 throw되도록 dev서버에서 변경됨에따라 
error상황일 경우, toast message를 보여주도록 변경했습니다.

혜성님 리뷰보고 히스토리를 다시파악했습니다! 확인결과 
```ts
// .../src/hooks/api/inspiration/useCheckLinkAvailable.ts
   // 여기서 https로 시작되지만 에러가 나면 if문에 들어가지않아 true로 바꾸지못해 무한 req
    if (isFetchedWith.current.https === false && link.startsWith('https') === false) {
      isFetchedWith.current.https = true;
      return `https://${link}`;
    }
   // 여기서 http로 시작되지만 에러가 나면 if문에 들어가지않아 true로 바꾸지못해 무한 req
    if (isFetchedWith.current.http === false && link.startsWith('http') === false) {
      isFetchedWith.current.http = true;
      return `http://${link}`;
    }
```
주석처럼 if문에 들어지못해 flag가 ture가 되지 못하는 결과로 무한 req가 발생해 getLinkWithProtocol 최하단에 아래의 코드를 추가했습니다.
```ts
  const getLinkWithProtocol = (link: string) => {

...
    isFetchedWith.current.http = true;
    isFetchedWith.current.https = true;
}
```
> 기존의 toast같은 경우도 지금 같은경우, 서버에서 내려주기에 기능으로 판단되어 상의이해 들어내면 좋을것같습니다. 엣지케이스를 다루려고 했지만 해성님과 한번 논의가 되야될것같아요!

<!-- 작업한 사항을 간략하게 적어주세요 -->

## 📸스크린샷
<img width="465" alt="스크린샷 2023-03-13 오후 10 43 58" src="https://user-images.githubusercontent.com/59507527/224724603-f8b3060c-375d-43d0-91c8-cdb658514e5b.png">

close #531 

<!--
리뷰어
혜성 : hyesungoh
도현 : ddarkr
대윤 : SenseCodeValue
은정 : positiveko
-->
