### PR TITLE
영감리스트 다음페이지 로딩 스피너 추가 스캘래톤 버전

### DIFF
--- a/src/components/common/Skeleton/Container.tsx
+++ b/src/components/common/Skeleton/Container.tsx
@@ -1,0 +1,90 @@
+import { PropsWithChildren } from 'react';
+import { css, Theme } from '@emotion/react';
+import { motion, Variants } from 'framer-motion';
+
+import { defaultEasing } from '~/constants/motions';
+import theme, { ThemeColor } from '~/styles/Theme/Theme';
+
+interface SkeletonContainerProps {
+  backgroundColorName?: ThemeColor;
+}
+
+function SkeletonContainer({
+  children,
+  backgroundColorName = 'gray03',
+}: PropsWithChildren<SkeletonContainerProps>) {
+  const backgroundColorRGB = hexToRGB(theme.color[backgroundColorName]);
+
+  return (
+    <div css={skeletonContainerCss}>
+      {children}
+      <motion.div
+        variants={shineVariants}
+        initial="initial"
+        animate="animate"
+        css={shineCss(backgroundColorRGB)}
+      ></motion.div>
+    </div>
+  );
+}
+
+export default SkeletonContainer;
+
+interface RGB {
+  red: number;
+  green: number;
+  blue: number;
+}
+
+const hexToRGB = (hex: string): RGB => {
+  const red = parseInt(hex.slice(1, 3), 16);
+  const green = parseInt(hex.slice(3, 5), 16);
+  const blue = parseInt(hex.slice(5, 7), 16);
+
+  return {
+    red,
+    green,
+    blue,
+  };
+};
+
+const shineVariants: Variants = {
+  initial: { y: 0, x: '0' },
+  animate: {
+    x: 'calc(100% + 200px)',
+    transition: { duration: 1.25, ease: defaultEasing, repeat: Infinity },
+    willChange: 'transform',
+  },
+};
+
+const skeletonContainerCss = (theme: Theme) =>
+  css`
+    position: relative;
+    border-radius: ${theme.borderRadius.default};
+    display: flex;
+    flex-direction: column;
+    justify-content: space-between;
+    gap: 6px;
+    width: 100%;
+    height: 100%;
+  `;
+
+const shineCss = (backgroundRGB: RGB) =>
+  css`
+    z-index: 1;
+    content: '';
+    display: block;
+    position: absolute;
+    top: 0;
+    left: -100px;
+    width: 100px;
+    height: 100%;
+    background: ${`linear-gradient(
+          90deg,
+          rgba(${backgroundRGB.red}, ${backgroundRGB.green}, ${backgroundRGB.blue}, 0),
+          rgba(${backgroundRGB.red}, ${backgroundRGB.green}, ${backgroundRGB.blue}, 0.5),
+          70%,
+          rgba(${backgroundRGB.red}, ${backgroundRGB.green}, ${backgroundRGB.blue}, 0) 90%
+        )`};
+    background-repeat: no-repeat;
+  `;

--- a/src/components/common/Skeleton/Thumbnail.tsx
+++ b/src/components/common/Skeleton/Thumbnail.tsx
@@ -1,0 +1,102 @@
+import { css, Theme } from '@emotion/react';
+import { motion } from 'framer-motion';
+
+import { contentFadeInUp } from '~/components/home/Thumbnail';
+
+import SkeletonContainer from './Container';
+
+function SkeletonThumbnail() {
+  return (
+    <motion.article css={wrapperCss} variants={contentFadeInUp}>
+      <div css={supportAspectRatioWrapperCss}>
+        <SkeletonContainer>
+          <div css={contentSkeletonCss}></div>
+          <div css={tagListSkeletonWrapper}>
+            <small css={tagSkeletonWrapper('sm')}></small>
+            <small css={tagSkeletonWrapper('lg')}></small>
+            <small css={tagSkeletonWrapper('md')}></small>
+            <small css={tagSkeletonWrapper('sm')}></small>
+          </div>
+        </SkeletonContainer>
+      </div>
+    </motion.article>
+  );
+}
+
+export default SkeletonThumbnail;
+
+const wrapperCss = (theme: Theme) => css`
+  max-width: 100%;
+  aspect-ratio: 1;
+  overflow: hidden;
+  color: ${theme.color.background};
+  background-color: ${theme.color.gray03};
+  border-radius: ${theme.borderRadius.outer};
+
+  @supports not (aspect-ratio: 1) {
+    position: relative;
+
+    &::before {
+      content: '';
+      float: left;
+      padding-top: 100%;
+    }
+    &::after {
+      content: '';
+      display: block;
+      clear: both;
+    }
+  }
+`;
+
+const supportAspectRatioWrapperCss = css`
+  width: 100%;
+  height: 100%;
+  padding: 6px;
+
+  @supports not (aspect-ratio: 1) {
+    position: absolute;
+    top: 0;
+    left: 0;
+  }
+`;
+
+const contentSkeletonCss = (theme: Theme) => css`
+  border-radius: ${theme.borderRadius.default};
+  height: calc(100% - 18px);
+  width: 100%;
+  background: ${theme.color.dim01};
+`;
+
+const tagListSkeletonWrapper = css`
+  display: flex;
+  align-items: center;
+  gap: 2px;
+  height: 16px;
+  width: 100%;
+`;
+
+type TagSize = 'sm' | 'md' | 'lg';
+
+const tagSizeToWidth = (size: TagSize) => {
+  switch (size) {
+    case 'sm':
+      return '32px';
+    case 'md':
+      return '48px';
+    case 'lg':
+      return '64px';
+    default:
+      return '32px';
+  }
+};
+
+const tagSkeletonWrapper = (size: TagSize) => (theme: Theme) => {
+  return css`
+    height: 100%;
+    width: ${tagSizeToWidth(size)};
+    padding: 2px 4px;
+    background-color: ${theme.color.dim02};
+    border-radius: ${theme.borderRadius.default};
+  `;
+};

--- a/src/components/common/Skeleton/index.tsx
+++ b/src/components/common/Skeleton/index.tsx
@@ -1,0 +1,2 @@
+export { default as SkeletonContainer } from './Container';
+export { default as SkeletonThumbnail } from './Thumbnail';

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -3,11 +3,11 @@ import { css } from '@emotion/react';
 import { motion } from 'framer-motion';
 
 import LoadingHandler from '~/components/common/LoadingHandler';
+import { SkeletonThumbnail } from '~/components/common/Skeleton';
 import { FixedSpinner } from '~/components/common/Spinner';
 import AppliedTags from '~/components/common/TagForm/AppliedTags';
 import AppendButton from '~/components/home/AppendButton';
 import { ClipboardAppMessageListener } from '~/components/home/ClipboardAppMessageListener';
-import EmptyImageSection from '~/components/home/EmptyImageSection';
 import HomeNavigationBar from '~/components/home/HomeNavigationBar';
 import Thumbnail from '~/components/home/Thumbnail';
 import { staggerHalf } from '~/constants/motions';
@@ -21,9 +21,13 @@ const InspirationViewAsModal = dynamic(
 );
 const EditTagFormRouteAsModal = dynamic(() => import('~/components/edit/EditTagFormRouteAsModal'));
 
+const nounce = new Date().getTime();
+const thumbnailSkeletonKeys = [nounce, nounce + 1];
+
 export default function Root() {
   const { filteredTags, removeTag } = useFilteredTags({});
-  const { inspirations, isEmpty, isLoading, hasNextPage, fetchNextPage } =
+
+  const { inspirations, isLoading, hasNextPage, fetchNextPage, isFetchingNextPage } =
     useGetInspirationListWithInfinite({
       filteredTags,
     });
@@ -47,7 +51,6 @@ export default function Root() {
         <LoadingHandler isLoading={isLoading} loadingComponent={<FixedSpinner />}>
           {/* NOTE: exit 애니메이션을 위해 삼항 연산자 사용 혹은 썸네일 섹션을 컨디셔널하게 렌더링할 시 */}
           {/* 해당 이미지 섹션이 렌더링되지 않음 */}
-          {isEmpty && <EmptyImageSection key="loading section" />}
           <motion.section
             css={thumbnailWrapperCss}
             layout
@@ -68,7 +71,8 @@ export default function Root() {
                 memo={memo}
               />
             ))}
-            {hasNextPage && !isLoading && <div ref={setTarget}></div>}
+            {isFetchingNextPage && thumbnailSkeletonKeys.map(id => <SkeletonThumbnail key={id} />)}
+            {hasNextPage && !isLoading && !isFetchingNextPage && <div ref={setTarget}></div>}
           </motion.section>
         </LoadingHandler>
       </motion.article>

--- a/src/styles/Theme/Theme.ts
+++ b/src/styles/Theme/Theme.ts
@@ -37,4 +37,6 @@ const theme = {
   },
 };
 
+export type ThemeColor = keyof typeof theme.color;
+
 export default theme;


### PR DESCRIPTION
## ⛳️작업 내용
영감리스트에 스켈레톤을 통해서 로딩상태를 볼 수 있도록했습니다.

그를 위해 `SkeletonContainer`, `SkeletonThumbnail` 2가지 컴포넌트를 만들었습니다.
`SkeletonContainer`는 Skeleton의 content들을 감싸며 그위에 shine 에니메이션을 보여주기위한 작업이 되어있습니다.
큰하나의 shine 에니메이션으로 한 요소의 전체로 뿌려주기위해 위와같은 방식을 채용했습니다.

`SkeletonThumbnail`은 말그대로 Thumbnail의 Skeleton입니다.


<!-- 작업한 사항을 간략하게 적어주세요 -->

## 📸스크린샷

https://user-images.githubusercontent.com/59507527/228573961-c71d7009-55cb-45bc-b47a-b1d4f053e75c.mov


<!-- 스크린샷으로 작업한 사항을 보여주세요 -->

## ⚡️사용 방법
```tsx
function SkeletonThumbnail() {
  return (
      <SkeletonContainer backgroundColorName="gray03"> // SkeletonContainer는 이런식으로 적용할 수 있습니다.
                <div css={contentSkeletonCss}></div>
                <div css={tagListSkeletonWrapper}>
                  <small css={tagSkeletonWrapper('sm')}></small>
                  <small css={tagSkeletonWrapper('lg')}></small>
                  <small css={tagSkeletonWrapper('md')}></small>
                  <small css={tagSkeletonWrapper('sm')}></small>
                </div>
              </SkeletonContainer>
   )
```
<!-- 공통 asset의 경우 사용법을 간략하게 적어봅시다 -->

## 📎레퍼런스
x
<!-- 참고한 레퍼런스가 있다면 기록해주세요 -->

<!--
리뷰어
혜성 : hyesungoh
도현 : ddarkr
대윤 : SenseCodeValue
은정 : positiveko
-->
