### PR TITLE
영감 삭제, 추가 시 로드 로직 변경

### DIFF
--- a/src/hooks/api/inspiration/useGetInspirationListWIthInfinite.ts
+++ b/src/hooks/api/inspiration/useGetInspirationListWIthInfinite.ts
@@ -19,7 +19,6 @@ interface InspirationResponseInterface extends PaginationInterface {
 
 const INFINITE_SCROLL_SIZE = 12;
 
-// TODO: 추가, 삭제, 수정 등 Mutation과 맞추기
 export const INSPIRATION_LIST_QUERY_KEY = 'inspirationList';
 
 interface UseGetInspirationListWithInfiniteProps {

--- a/src/hooks/api/inspiration/useInspirationMutation.ts
+++ b/src/hooks/api/inspiration/useInspirationMutation.ts
@@ -27,7 +27,6 @@ export default function useInspirationMutation(param?: InspirationMutationParams
   const { postMessage } = useWebViewMessage();
 
   const refreshInspirationList = () => {
-    queryClient.invalidateQueries([INSPIRATION_LIST_QUERY_KEY]);
     queryClient.refetchQueries([INSPIRATION_LIST_QUERY_KEY]);
   };
 

--- a/src/hooks/api/inspiration/useInspirationMutation.ts
+++ b/src/hooks/api/inspiration/useInspirationMutation.ts
@@ -28,6 +28,7 @@ export default function useInspirationMutation(param?: InspirationMutationParams
 
   const refreshInspirationList = () => {
     queryClient.invalidateQueries([INSPIRATION_LIST_QUERY_KEY]);
+    queryClient.refetchQueries([INSPIRATION_LIST_QUERY_KEY]);
   };
 
   const resetInspirationList = () => {
@@ -51,7 +52,8 @@ export default function useInspirationMutation(param?: InspirationMutationParams
     {
       onSuccess: () => {
         fireToast({ content: '영감을 등록했습니다.' });
-        resetInspirationList();
+
+        refreshInspirationList();
         postMessage(WEBVIEW_MESSAGE_TYPE.CreatedInspiration);
       },
       onError: (error, variable, context) => {
@@ -65,7 +67,7 @@ export default function useInspirationMutation(param?: InspirationMutationParams
     (id: number) => del(`/v1/inspiration/remove/${id}`),
     {
       onSuccess: () => {
-        resetInspirationList();
+        refreshInspirationList();
         push('/');
       },
       onError: (error, variable, context) => {


### PR DESCRIPTION
## ⛳️작업 내용

- 기존 query를 reset하던 행동에서, refetch하는 행동으로 바꿨습니다

> reset은 아예 캐싱된 값을 비워 `리스트 > 추가or삭제 >  없음 > 리스트` 임에 반해
>
> 바꾼 동작은 `리스트 > 추가or삭제 > 리스트 > 조회가 다 되면 > 리스트를 업데이트`해서 사용자 경험이 더 좋을 거라 생각했어요

- `invalidate`를 사용하지 않은 이유
  - 유효하지 않음을 표기하는 `invalidate`는 `사용자가 필요하게 될 때` 다시 조회해서 더 효과적이라고 공식 문서에서 말하고 있어요
  - 근데 저희는 `route as modal` 방법이라 그런지... (추측) 생성 시에는 `사용자가 필요하게 될 때`라고 판단하지 않는 거 같아요
    - 코드를 읽기 힘들어지는 거 같기도하고 .. 다른 방법으로 마이그레이션해봐도 ... 좋을듯 합니다
  

## 📸스크린샷




### as is

https://user-images.githubusercontent.com/26461307/225591138-48fbe4a6-65f3-4e32-a584-c25cd2c94472.mov


### to be

https://user-images.githubusercontent.com/26461307/225587156-d3e74d68-827f-431b-b4dd-121919c75a6e.mov


<!-- 스크린샷으로 작업한 사항을 보여주세요 -->

## ⚡️사용 방법

<!-- 공통 asset의 경우 사용법을 간략하게 적어봅시다 -->

## 📎레퍼런스

<!-- 참고한 레퍼런스가 있다면 기록해주세요 -->

<!--
리뷰어
혜성 : hyesungoh
도현 : ddarkr
대윤 : SenseCodeValue
은정 : positiveko
-->
