### PR TITLE
fix: 안드로이드 다음페이지 트리거 이슈

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -72,9 +72,7 @@ export default function Root() {
               />
             ))}
             {isFetchingNextPage && thumbnailSkeletonKeys.map(id => <SkeletonThumbnail key={id} />)}
-            {hasNextPage && !isLoading && !isFetchingNextPage && (
-              <div css={nextPageTriggerCss} ref={setTarget}></div>
-            )}
+            {hasNextPage && !isLoading && !isFetchingNextPage && <div ref={setTarget}></div>}
           </motion.section>
         </LoadingHandler>
       </motion.article>
@@ -94,10 +92,6 @@ const thumbnailWrapperCss = css`
   display: grid;
   grid-template-columns: 1fr 1fr;
   gap: 8px;
-`;
-
-const nextPageTriggerCss = css`
-  margin-top: -5px;
 `;
 
 const filteredSectionCss = css`

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -72,7 +72,9 @@ export default function Root() {
               />
             ))}
             {isFetchingNextPage && thumbnailSkeletonKeys.map(id => <SkeletonThumbnail key={id} />)}
-            {hasNextPage && !isLoading && !isFetchingNextPage && <div ref={setTarget}></div>}
+            {hasNextPage && !isLoading && !isFetchingNextPage && (
+              <div css={nextPageTriggerCss} ref={setTarget}></div>
+            )}
           </motion.section>
         </LoadingHandler>
       </motion.article>
@@ -88,9 +90,14 @@ export default function Root() {
 const thumbnailWrapperCss = css`
   width: 100%;
   padding-top: 16px;
+  padding-bottom: 5px;
   display: grid;
   grid-template-columns: 1fr 1fr;
   gap: 8px;
+`;
+
+const nextPageTriggerCss = css`
+  margin-top: -5px;
 `;
 
 const filteredSectionCss = css`


### PR DESCRIPTION
## ⛳️작업 내용
안드로이드 크롬 테스트에서 다음페이지 트리거를 못보는 현상이 있습니다.
하단이 너무 붙어있어 트리거를 호출하지 못하는 이슈 였습니다. 따라서 하단에 약간의 공간을 두고 그만큼 트리거 요소를 올려서 observer가 볼 수 있도록했습니다.

스크린샷 아침에 첨부예정...

close #553 

<!--
리뷰어
혜성 : hyesungoh
도현 : ddarkr
대윤 : SenseCodeValue
은정 : positiveko
-->
