### PR TITLE
feat: 회원가입 시 연령 선택 제거

### DIFF
--- a/src/hooks/api/sign-up/usePatchExtraInformation.ts
+++ b/src/hooks/api/sign-up/usePatchExtraInformation.ts
@@ -5,7 +5,6 @@ import { useToast } from '~/store/Toast';
 
 export interface ExtraInformationParams {
   email: string;
-  age: string;
   job: string;
   gender: string;
 }

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -8,6 +8,7 @@ import { FixedSpinner } from '~/components/common/Spinner';
 import AppliedTags from '~/components/common/TagForm/AppliedTags';
 import AppendButton from '~/components/home/AppendButton';
 import { ClipboardAppMessageListener } from '~/components/home/ClipboardAppMessageListener';
+import EmptyImageSection from '~/components/home/EmptyImageSection';
 import HomeNavigationBar from '~/components/home/HomeNavigationBar';
 import Thumbnail from '~/components/home/Thumbnail';
 import { staggerHalf } from '~/constants/motions';
@@ -27,7 +28,7 @@ const thumbnailSkeletonKeys = [nounce, nounce + 1];
 export default function Root() {
   const { filteredTags, removeTag } = useFilteredTags({});
 
-  const { inspirations, isLoading, hasNextPage, fetchNextPage, isFetchingNextPage } =
+  const { inspirations, isEmpty, isLoading, hasNextPage, fetchNextPage, isFetchingNextPage } =
     useGetInspirationListWithInfinite({
       filteredTags,
     });
@@ -51,6 +52,7 @@ export default function Root() {
         <LoadingHandler isLoading={isLoading} loadingComponent={<FixedSpinner />}>
           {/* NOTE: exit 애니메이션을 위해 삼항 연산자 사용 혹은 썸네일 섹션을 컨디셔널하게 렌더링할 시 */}
           {/* 해당 이미지 섹션이 렌더링되지 않음 */}
+          {isEmpty && <EmptyImageSection key="loading section" />}
           <motion.section
             css={thumbnailWrapperCss}
             layout

--- a/src/pages/signup/information.tsx
+++ b/src/pages/signup/information.tsx
@@ -17,15 +17,6 @@ import { recordEvent } from '~/utils/analytics';
 const GENDER_VALUES = ['남자', '여자', '기타'] as const;
 const GENDER_REQUEST_VALUES = { 남자: 'MALE', 여자: 'FEMALE', 기타: 'ETC' } as const;
 
-const AGE_VALUES = ['20세 미만', '20~24세', '25~29세', '30~34세', '35세 이상'] as const;
-const AGE_REQUEST_VALUES = {
-  '20세 미만': 'UNDER_20S',
-  '20~24세': 'EARLY_20S',
-  '25~29세': 'LATE_20S',
-  '30~34세': 'EARLY_30S',
-  '35세 이상': 'OLDER_35',
-} as const;
-
 const JOB_VALUES = [
   '디자인, 예술',
   'IT, 개발, 데이터',
@@ -42,17 +33,16 @@ export default function Information() {
   const router = useInternalRouter();
 
   const [gender, setGender] = useState<(typeof GENDER_VALUES)[number] | null>(null);
-  const [age, setAge] = useState<(typeof AGE_VALUES)[number] | null>(null);
   const [job, setJob] = useState<string | null>(null);
 
   const { mutate: signupMutate } = useSignupMutation();
   const { userLogin } = useUser();
   const { mutate: putExtraInformationMutate } = usePutExtraInformation();
 
-  const isDisabledCTAButton = !Boolean(gender && age && job);
+  const isDisabledCTAButton = !Boolean(gender && job);
 
   const onClickCTA = () => {
-    if (!queryEmail || !gender || !job || !age || !signupUser) return;
+    if (!queryEmail || !gender || !job || !signupUser) return;
 
     signupMutate(
       {
@@ -79,7 +69,6 @@ export default function Information() {
             {
               email: queryEmail,
               gender: GENDER_REQUEST_VALUES[gender],
-              age: AGE_REQUEST_VALUES[age],
               job,
             },
             {
@@ -87,10 +76,6 @@ export default function Information() {
                 recordEvent({
                   action: '사용자 성별',
                   value: gender,
-                });
-                recordEvent({
-                  action: '사용자 나이',
-                  value: age,
                 });
                 recordEvent({
                   action: '사용자 관심 직군',
@@ -113,7 +98,6 @@ export default function Information() {
       <p css={introTextWrapper}>마지막 단계입니다!</p>
       <section css={sectionCss}>
         <DropdownMenu label="성별" values={GENDER_VALUES} value={gender} setValue={setGender} />
-        <DropdownMenu label="나이" values={AGE_VALUES} value={age} setValue={setAge} />
         <DropdownMenu label="관심 직무" values={JOB_VALUES} value={job} setValue={setJob} />
       </section>
 


### PR DESCRIPTION
## ⛳️작업 내용
ios의 심의 결과 연령에 대한 정보를 앱에서 사용하지 않지만 수집을하고 있어
선택 안함 또는 수집을 안하는 방향중 수집을 안하는 방향으로 결정되어 개발을 진행합니다.

추가적으로 지난 스캘래톤 적용하면서 제거되었던 empty list 컴포넌트를 다시 추가했습니다.
<!-- 작업한 사항을 간략하게 적어주세요 -->

## 📸스크린샷
### 드롭다운이 제거되었으며, 정상 가입되었습니다.
<img width="695" alt="스크린샷 2023-04-05 오전 1 02 57" src="https://user-images.githubusercontent.com/59507527/229852471-95aedf65-5463-479e-9421-4a43b72770e3.png">

### empty list
<img width="721" alt="image" src="https://user-images.githubusercontent.com/59507527/229852705-23de24ae-e603-4792-b49b-c5b6c7af7591.png">

<!-- 스크린샷으로 작업한 사항을 보여주세요 -->

<!--
리뷰어
혜성 : hyesungoh
도현 : ddarkr
대윤 : SenseCodeValue
은정 : positiveko
-->
