### PR TITLE
이메일 Input select box 추가

### DIFF
--- a/src/components/common/DropdownMenu/DropdownMenu.tsx
+++ b/src/components/common/DropdownMenu/DropdownMenu.tsx
@@ -38,7 +38,7 @@ export default function DropdownMenu<T extends readonly string[]>({
         </label>
       )}
 
-      <button onClick={toggleIsOpen} css={buttonCss}>
+      <button type="button" onClick={toggleIsOpen} css={buttonCss}>
         {value ?? '선택하기'}
 
         <ChevronIcon direction="down" />

--- a/src/components/common/TextField/TextField.tsx
+++ b/src/components/common/TextField/TextField.tsx
@@ -99,7 +99,7 @@ const wrapperCss = css`
   gap: 6px;
 `;
 
-const feedbackMessageCss = (
+export const feedbackMessageCss = (
   theme: Theme,
   { alertWhenFocused }: { alertWhenFocused: boolean }
 ) => css`

--- a/src/components/signup/EmailFeild.tsx
+++ b/src/components/signup/EmailFeild.tsx
@@ -1,0 +1,102 @@
+import { ReactNode, useEffect, useState } from 'react';
+import { css, useTheme } from '@emotion/react';
+
+import DropdownMenu from '../common/DropdownMenu';
+import TextField from '../common/TextField';
+import { feedbackMessageCss } from '../common/TextField/TextField';
+
+const DOMAIN_VALUES = [
+  'naver.com',
+  'gmail.com',
+  'kakao.com',
+  'daum.net',
+  'hanmail.net',
+  '직접 입력',
+] as const;
+
+export default function EmailFeild({
+  setEmail,
+  feedback,
+}: {
+  setEmail: (value: string) => void;
+  feedback: ReactNode;
+}) {
+  const theme = useTheme();
+  const [emailId, setEmailId] = useState('');
+  const [domain, setDomain] = useState('');
+  const [selectedDomain, setSelectedDomain] = useState<(typeof DOMAIN_VALUES)[number] | null>(null);
+
+  const isDirectInput = selectedDomain === '직접 입력';
+
+  useEffect(() => {
+    if (emailId && domain) setEmail(emailId + '@' + domain);
+  }, [setEmail, emailId, domain]);
+
+  useEffect(() => {
+    if (!selectedDomain || isDirectInput) {
+      setDomain('');
+      return;
+    }
+    if (!isDirectInput) setDomain(selectedDomain);
+  }, [selectedDomain, isDirectInput]);
+
+  return (
+    <div>
+      <div css={textFieldContainerCss}>
+        <TextField
+          placeholder={'이메일 아이디'}
+          type="text"
+          value={emailId}
+          onChange={e => {
+            setEmailId(e.target.value);
+          }}
+          required
+          alertWhenFocused
+        />
+        <p>@</p>
+        <TextField
+          disabled={!isDirectInput}
+          placeholder={isDirectInput || !selectedDomain ? 'email.com' : selectedDomain}
+          type="text"
+          value={isDirectInput ? domain : ''}
+          onChange={e => {
+            setDomain(e.target.value);
+          }}
+          required
+          alertWhenFocused
+        />
+      </div>
+      <DropdownMenu
+        css={domainSelectorCss}
+        values={DOMAIN_VALUES}
+        value={selectedDomain}
+        setValue={setSelectedDomain}
+      />
+      {feedback &&
+        (typeof feedback === 'string' ? (
+          <p css={feedbackMessageCss(theme, { alertWhenFocused: true })}>{feedback}</p>
+        ) : (
+          feedback
+        ))}
+    </div>
+  );
+}
+
+const textFieldContainerCss = css`
+  display: flex;
+  gap: 12px;
+
+  margin-bottom: 18px;
+
+  & > div {
+    width: 100%;
+  }
+
+  p {
+    display: flex;
+    align-items: center;
+    height: 54px;
+  }
+`;
+
+const domainSelectorCss = css``;

--- a/src/components/signup/EmailFeild.tsx
+++ b/src/components/signup/EmailFeild.tsx
@@ -66,12 +66,7 @@ export default function EmailFeild({
           alertWhenFocused
         />
       </div>
-      <DropdownMenu
-        css={domainSelectorCss}
-        values={DOMAIN_VALUES}
-        value={selectedDomain}
-        setValue={setSelectedDomain}
-      />
+      <DropdownMenu values={DOMAIN_VALUES} value={selectedDomain} setValue={setSelectedDomain} />
       {feedback &&
         (typeof feedback === 'string' ? (
           <p css={feedbackMessageCss(theme, { alertWhenFocused: true })}>{feedback}</p>
@@ -98,5 +93,3 @@ const textFieldContainerCss = css`
     height: 54px;
   }
 `;
-
-const domainSelectorCss = css``;

--- a/src/pages/signup/index.tsx
+++ b/src/pages/signup/index.tsx
@@ -7,7 +7,7 @@ import NavigationBar from '~/components/common/NavigationBar';
 import PortalWrapper from '~/components/common/PortalWrapper';
 import SEO from '~/components/common/SEO';
 import { FixedSpinner } from '~/components/common/Spinner';
-import TextField from '~/components/common/TextField';
+import EmailFeild from '~/components/signup/EmailFeild';
 import useSignupSendEmailMutation from '~/hooks/api/auth/useSignupSendEmailMutation';
 import useInput from '~/hooks/common/useInput';
 import { get } from '~/libs/api/client';
@@ -46,15 +46,9 @@ export default function Signup() {
           </p>
         </div>
         <form css={fieldSetCss} onSubmit={onSubmit}>
-          <TextField
-            placeholder={'이메일을 입력해주세요'}
-            type="email"
-            value={email.value}
-            onChange={email.onChange}
+          <EmailFeild
+            setEmail={email.setValue}
             feedback={email.debouncedValue !== '' ? emailError || <>&nbsp;</> : <>&nbsp;</>}
-            isSuccess={email.debouncedValue.length > 0 && emailError === ''}
-            required
-            alertWhenFocused
           />
           <CTAButton type={'submit'} disabled={isCTAButtonDisabled}>
             다음


### PR DESCRIPTION
## ⛳️작업 내용
기존 이메일 도메인에 대한 오류가 발생하는것을 파악하여 해당 이슈를 해결하기위해서 domain을 선택하는 화면을 추가하는 기획에 대한 결과물입니다.

`TextFeild`와 `Dropdownmenu` 컴포넌트를 이용해서 `EmailFeild`라는 컴포넌트를 구현했습니다.

<!-- 작업한 사항을 간략하게 적어주세요 -->

## 📸스크린샷
<img width="532" alt="스크린샷 2023-05-27 오전 5 05 01" src="https://github.com/depromeet/ygtang-client/assets/59507527/ebfafcf8-b965-42e6-848c-559ad8a2ebf2">
<img width="532" alt="스크린샷 2023-05-27 오전 5 05 13" src="https://github.com/depromeet/ygtang-client/assets/59507527/b7f91020-3a91-4ac9-9695-31e6af41e6a0">

<!-- 스크린샷으로 작업한 사항을 보여주세요 -->

## ⚡️사용 방법

`EmailFeild는 기존의 환경에서 많은 것을 변경하기 보다는 입력에따라 email을 set해주는 정도의 작업을 진행하도록했습니다.

```tsx
const email = useInput({ useDebounce: true });
  const [emailError, setEmailError] = useState('');

  useEffect(() => {
    if (!validator({ type: 'email', value: email.debouncedValue })) {
      setEmailError('올바른 이메일을 입력해주세요.');
    } else {
      setEmailError('');
    }
  }, [email.debouncedValue]);

<EmailFeild
  setEmail={email.setValue}
  feedback={email.debouncedValue !== '' ? emailError || <>&nbsp;</> : <>&nbsp;</>}
/>
```

<!-- 공통 asset의 경우 사용법을 간략하게 적어봅시다 -->

## 📎레퍼런스
마이 브레인
<!-- 참고한 레퍼런스가 있다면 기록해주세요 -->

<!--
리뷰어
혜성 : hyesungoh
도현 : ddarkr
대윤 : SenseCodeValue
은정 : positiveko
-->
