### PR TITLE
feat: add caching time to get tag list

### DIFF
--- a/src/hooks/api/tag/useGetTagListWithInfinite.ts
+++ b/src/hooks/api/tag/useGetTagListWithInfinite.ts
@@ -52,6 +52,8 @@ export default function useGetTagListWithInfinite({ keyword, isExactlySame = fal
         if (firstPage.data.first) return undefined;
         return firstPage.data.number - 1 ?? undefined;
       },
+      staleTime: 5000,
+      cacheTime: 5000,
     }
   );
 


### PR DESCRIPTION
## ⛳️작업 내용

태그 리스트를 검색하는 use-query에 캐싱 타임을 추가해, 비효율적인 api 호출을 방지합니다.

사실 제 개인적인 의견으로는 Infinity로 걸어둬도 될 것 같은 곳이지만, 제 개인적인 사견이기 때문에 캐싱 타임은 적정 시간인 5s로 지정했습니다.

5s 선정 기준
-> 현재는 작성한 태그를 지우는 과정에도 api 호출을 다시 합니다. 이를 방지하고자 캐싱 타임을 추가했기 때문에 초단위의 시간 설정이 필요하다 생각했습니다.

### 개선할 수 있는 다른 방향

useInfiniteQuery 와 검색창의 input value를 분리합니다.
현재는 값이 양방향 바인딩이 되어있어 입력한 값 그대로 호출되는 방식이기에, 값을 분리하고 debounce를 걸어줍니다.

저는 위 방법으로 검색 ui 최적화를 적용한 경험이 있는데, 현재 영감탱-client의 구조에 적용하기에는 많은 수정사항이 필요할 것 같아 의견을 여쭤봅니다!

https://github.com/depromeet/ygtang-client/assets/57122180/6cb1b7c0-b9b6-4704-ae99-d48190ee7b89

디바운스를 적용한 예시
모든 값에 대한 api 요청을 하는 것이 아닌, 0.1s의 딜레이를 걸어뒀습니다.

## 📸스크린샷

Before

https://github.com/depromeet/ygtang-client/assets/57122180/408101b2-ae3a-4f98-84c4-4edbf1659242

After

https://github.com/depromeet/ygtang-client/assets/57122180/f341aaa7-a72c-4461-836e-b011fd27978b


## ⚡️사용 방법

<!-- 공통 asset의 경우 사용법을 간략하게 적어봅시다 -->

## 📎레퍼런스

<!-- 참고한 레퍼런스가 있다면 기록해주세요 -->

<!--
리뷰어
혜성 : hyesungoh
도현 : ddarkr
대윤 : SenseCodeValue
은정 : positiveko
-->
