### PR TITLE
태그 추가 시 mutation 타입 맞추기

### DIFF
--- a/src/pages/add/tag.tsx
+++ b/src/pages/add/tag.tsx
@@ -42,7 +42,7 @@ export default function TagPage() {
       createTag(keyword, {
         onSuccess: data => {
           recordEvent({ action: '태그 생성', value: keyword, label: '영감 편집 화면' });
-          addTag(data);
+          addTag({ ...data, count: 1 });
           tagListRefresh();
         },
       });

--- a/src/pages/edit/tag.tsx
+++ b/src/pages/edit/tag.tsx
@@ -78,7 +78,7 @@ export default function EditTag() {
     createTag(keyword, {
       onSuccess: data => {
         recordEvent({ action: '태그 생성', value: keyword, label: '영감 편집 화면' });
-        saveTag(data);
+        saveTag({ ...data, count: 1 });
         tagListRefresh();
       },
     });


### PR DESCRIPTION
## ⛳️작업 내용

`CreateTagDataResponseInterface`에서는 id와 content만 가지고 있어요

> 기존에는 태그 개수를 보여주지 않아서 그랬던 것으로 보여요

하지만 바뀌어진 TagType에는 `count` 필드도 추가되어서 타입 때문에 빌드가 안되는 이슈가 있었어용

> 제가 이해한게 아니라면 말씀 부탁드려요 !!

고래서 

새로운 태그를 생성할 때는 1개일테니, 1을 낙관적으로 넣어주었습니당 

> 이후에 query를 reset해서 완전 낙관적이라기보다는 구색맞추기인 거 같긴 한데 ... 

머윤님이 봐주시면 조흘거 같습니다 👍 👍 