### PR TITLE
영감탱 익스텐션 로그인 핸들링

### DIFF
--- a/src/components/common/Dialog.tsx
+++ b/src/components/common/Dialog.tsx
@@ -1,5 +1,5 @@
 import { PropsWithChildren, ReactNode, useEffect, useState } from 'react';
-import { css, Theme } from '@emotion/react';
+import { css, Theme, useTheme } from '@emotion/react';
 import { motion } from 'framer-motion';
 
 import PortalWrapper from '~/components/common/PortalWrapper';
@@ -10,13 +10,16 @@ import { dimBackdropCss } from './styles';
 export interface DialogProps {
   isShowing?: boolean;
   actionButtons: ReactNode;
+  dialogWidth?: number;
 }
 
 export default function Dialog({
   isShowing,
   children,
   actionButtons,
+  dialogWidth,
 }: PropsWithChildren<DialogProps>) {
+  const theme = useTheme();
   const [isSSR, setIsSSR] = useState(true);
 
   useEffect(() => {
@@ -34,7 +37,7 @@ export default function Dialog({
           animate="animate"
           exit="exit"
         >
-          <motion.div css={dialogCss} variants={defaultFadeInUpVariants}>
+          <motion.div css={dialogCss(theme, dialogWidth)} variants={defaultFadeInUpVariants}>
             <div css={dialogContentWrapperCss}>{children}</div>
             <div css={dialogButtonWrapperCss}>{actionButtons}</div>
           </motion.div>
@@ -54,14 +57,14 @@ const dimBackdropLayoutCss = (theme: Theme) => css`
   ${dimBackdropCss(theme)}
 `;
 
-const dialogCss = (theme: Theme) => css`
+const dialogCss = (theme: Theme, width = 311) => css`
   position: relative;
   display: flex;
   flex-direction: column;
   align-items: center;
   justify-content: flex-end;
 
-  width: 311px;
+  width: ${width}px;
   min-height: 200px;
 
   background-color: ${theme.color.background};

--- a/src/constants/localStorage.ts
+++ b/src/constants/localStorage.ts
@@ -2,3 +2,8 @@ export const localStorageUserTokenKeys = {
   accessToken: 'ygtlsat',
   refreshToken: 'ygtrfhtk',
 } as const;
+
+export const localStorageExtensionKeys = {
+  use: 'use-ygtang-extension',
+  refreshToken: 'ygte-refresh',
+} as const;

--- a/src/libs/api/client.ts
+++ b/src/libs/api/client.ts
@@ -6,7 +6,7 @@ import CustomException from '~/exceptions/CustomException';
 import { errorMessage } from '~/exceptions/messages';
 import { ApiErrorScheme } from '~/exceptions/type';
 
-const DEVELOPMENT_API_URL = 'https://api.ygtang.xyz/api';
+const DEVELOPMENT_API_URL = 'https://ygtang.kr/api'; // TODO: 개발 서버 사망에 따른 개발 버전에서도 프로덕션 사용
 const PRODUCTION_API_URL = 'https://ygtang.kr/api';
 
 export const instance = axios.create({

--- a/src/pages/login/index.tsx
+++ b/src/pages/login/index.tsx
@@ -120,13 +120,18 @@ export default function Login() {
   }, [fireToast, loginMutationError]);
 
   useEffect(() => {
-    if (
-      localStorage &&
-      localStorage.getItem(localStorageExtensionKeys.use) &&
-      localStorage.getItem(localStorageExtensionKeys.refreshToken)
-    ) {
-      setCanExtensionLogin(true);
-    }
+    const checkLoginAvailable = () => {
+      if (localStorage.getItem(localStorageExtensionKeys.refreshToken)) {
+        setCanExtensionLogin(true);
+      } else {
+        setCanExtensionLogin(false);
+      }
+    };
+    checkLoginAvailable();
+    const interval = setInterval(checkLoginAvailable, 3000);
+    return () => {
+      clearInterval(interval);
+    };
   }, []);
 
   return (

--- a/src/pages/login/index.tsx
+++ b/src/pages/login/index.tsx
@@ -23,6 +23,7 @@ export default function Login() {
   const password = useInput({});
   const [isPending, setIsPending] = useState(false);
   const [canExtensionLogin, setCanExtensionLogin] = useState(false);
+  const [userCancelExtensionLogin, setUserCancelExtensionLogin] = useState(false);
   const [emailError, setEmailError] = useState('');
   const [passwordError, setPasswordError] = useState('');
   const { userLogin } = useUser();
@@ -121,6 +122,9 @@ export default function Login() {
 
   useEffect(() => {
     const checkLoginAvailable = () => {
+      if (userCancelExtensionLogin) {
+        return;
+      }
       if (localStorage.getItem(localStorageExtensionKeys.refreshToken)) {
         setCanExtensionLogin(true);
       } else {
@@ -132,6 +136,7 @@ export default function Login() {
     return () => {
       clearInterval(interval);
     };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   return (
@@ -176,13 +181,13 @@ export default function Login() {
           </GhostButton>
         </div>
         <Dialog
-          isShowing={canExtensionLogin}
+          isShowing={!userCancelExtensionLogin && canExtensionLogin}
           dialogWidth={300}
           actionButtons={
             <>
               <FilledButton
                 colorType="light"
-                onClick={() => setCanExtensionLogin(false)}
+                onClick={() => setUserCancelExtensionLogin(true)}
                 disabled={isPending}
               >
                 다른 계정


### PR DESCRIPTION
## ⛳️작업 내용

<!-- 작업한 사항을 간략하게 적어주세요 -->

- 영감탱 익스텐션의 로그인 정보를 받아와서, 사용자에게 로그인 할 것인지 묻습니다.
  - `/login`에서만 동작하도록 구현했습니다. (비로그인 사용자에게만 의견 묻도록)
  - 유저가 버튼을 통해 취소하는 경우, 더 이상 물어보지 않습니다. 
- 익스텐션의 로그인 정보는 3초마다 localStorage를 통해 가져옵니다.

## 📸스크린샷

<!-- 스크린샷으로 작업한 사항을 보여주세요 -->

![image](https://github.com/depromeet/ygtang-client/assets/6638675/e1d2f206-9951-4a3a-b59e-0aefb5ed70d8)

## ⚡️사용 방법

<!-- 공통 asset의 경우 사용법을 간략하게 적어봅시다 -->

## 📎레퍼런스

<!-- 참고한 레퍼런스가 있다면 기록해주세요 -->

<!--
리뷰어
혜성 : hyesungoh
도현 : ddarkr
대윤 : SenseCodeValue
은정 : positiveko
-->
